### PR TITLE
fix: update office address unit to #06-28

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -58,7 +58,7 @@ export function Footer() {
           {/* Company Info */}
           <div className="text-center space-y-2">
             <p className="text-sm font-medium text-slate-900 dark:text-slate-100">{appName}</p>
-            <p className="text-xs text-slate-600 dark:text-slate-400">60 PAYA LEBAR ROAD, #07-54, PAYA LEBAR SQUARE</p>
+            <p className="text-xs text-slate-600 dark:text-slate-400">60 PAYA LEBAR ROAD, #06-28, PAYA LEBAR SQUARE</p>
             <p className="text-xs text-slate-600 dark:text-slate-400">SINGAPORE 409051</p>
           </div>
 

--- a/src/pages/legal/2025-09-26/privacy.tsx
+++ b/src/pages/legal/2025-09-26/privacy.tsx
@@ -298,7 +298,7 @@ export default function PrivacyPolicy() {
                 <strong>Email:</strong> chingwee@lazytax.club
               </p>
               <p>
-                <strong>Address:</strong> 60 PAYA LEBAR ROAD, #07-54, PAYA LEBAR SQUARE, SINGAPORE 409051
+                <strong>Address:</strong> 60 PAYA LEBAR ROAD, #06-28, PAYA LEBAR SQUARE, SINGAPORE 409051
               </p>
               <p>
                 For general privacy questions or to exercise your data subject rights, contact our Privacy Officer. For


### PR DESCRIPTION
Updates the displayed office address unit number from `#07-54` to `#06-28`.

New address:

```
BUNNYBOOKER
60 Paya Lebar Road
#06-28 Paya Lebar Square
Singapore 409051
```

## Changes
- `src/components/Footer.tsx` — footer company address
- `src/pages/legal/2025-09-26/privacy.tsx` — privacy policy contact address

Street, building (Paya Lebar Square), and postal code (409051) are unchanged; only the unit number differs. The company name in the footer is rendered dynamically via `{appName}`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated company address information displayed in the footer.
  * Updated Privacy Officer contact address in the Privacy Policy documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->