### PR TITLE
feat: public account-deletion page

### DIFF
--- a/src/adapters/atomi/next.ts
+++ b/src/adapters/atomi/next.ts
@@ -165,7 +165,7 @@ const withApiAtomi: WithApiHandler<AdaptedInput, AtomiOutput> = (
   });
 };
 
-const withApiLogtoOnly: WithApiHandler<AdaptedInput, LogtoClient> = (
+const withApiLogtoOnly: WithApiHandler<AdaptedInput, { client: LogtoClient; baseUrl: string }> = (
   { importedConfigurations, landscapeSource, defaultInstance, clientTree, configSchemas, problemDefinitions },
   handler,
 ) => {
@@ -189,7 +189,9 @@ const withApiLogtoOnly: WithApiHandler<AdaptedInput, LogtoClient> = (
             scopes: config.server.auth.logto.scopes,
           },
           (req, res, { client }) => {
-            return handler(req, res, client);
+            // Expose the trusted, configured app base URL so the sign-in route can build the
+            // OAuth redirect/return URIs from it instead of from spoofable request headers.
+            return handler(req, res, { client, baseUrl: config.server.auth.logto.url });
           },
         )(req, res);
       },

--- a/src/pages/account-deletion.tsx
+++ b/src/pages/account-deletion.tsx
@@ -1,0 +1,193 @@
+import { useState } from 'react';
+import type { GetServerSidePropsResult } from 'next';
+import Head from 'next/head';
+import { withServerSideAtomi } from '@/adapters/atomi/next';
+import { buildTime } from '@/adapters/external/core';
+import { useSwaggerClients } from '@/adapters/external/Provider';
+import { useProblemReporter } from '@/adapters/problem-reporter/providers/hooks';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import type { Problem } from '@/lib/problem/core';
+import { AlertTriangle, ShieldX, CheckCircle2 } from 'lucide-react';
+
+// Public account-deletion page (Google Play requirement): a logged-out visitor who has
+// uninstalled the app can still delete their account from the web. The visitor must prove
+// ownership by signing in, then confirm an irreversible deletion. On success we sign them out.
+const RETURN_PATH = '/account-deletion';
+// Return the visitor to this page after the Logto round-trip (handled by /api/logto/sign-in).
+const SIGN_IN_HREF = `/api/logto/sign-in?redirectBackUrl=${encodeURIComponent(RETURN_PATH)}`;
+const SIGN_OUT_HREF = '/api/logto/sign-out';
+const CONFIRM_PHRASE = 'DELETE';
+
+type AccountDeletionProps = { authed: boolean };
+
+type DeleteState =
+  | { kind: 'idle' }
+  | { kind: 'deleting' }
+  | { kind: 'deleted' }
+  | { kind: 'debt'; detail: string; amount?: string }
+  | { kind: 'error'; detail: string };
+
+function formatDebt(problem: Problem): { detail: string; amount?: string } {
+  // The zinc `account_deletion_blocked` problem carries totalDebt + currency as extension members.
+  const totalDebt = problem.totalDebt;
+  const currency = typeof problem.currency === 'string' ? problem.currency : '';
+  const amount =
+    typeof totalDebt === 'number' || typeof totalDebt === 'string'
+      ? `${totalDebt}${currency ? ` ${currency}` : ''}`
+      : undefined;
+  return { detail: problem.detail || 'You have an outstanding debt that must be settled first.', amount };
+}
+
+export default function AccountDeletionPage({ authed }: AccountDeletionProps) {
+  const api = useSwaggerClients();
+  const problemReporter = useProblemReporter();
+  const [confirmText, setConfirmText] = useState('');
+  const [state, setState] = useState<DeleteState>({ kind: 'idle' });
+
+  const canConfirm = confirmText.trim().toUpperCase() === CONFIRM_PHRASE && state.kind !== 'deleting';
+
+  const handleDelete = async () => {
+    if (!canConfirm) return;
+    setState({ kind: 'deleting' });
+
+    // DELETE /api/v1.0/User/Me — the SDK has no dedicated "Me" delete method, but vUserDelete builds
+    // `/User/${id}`, so id='Me' produces exactly that URL, which routes to zinc's self-delete endpoint
+    // (the literal `Me` segment wins over `{id}`). The Logto bearer is attached by the client.
+    const result = await api.alcohol.zinc.api.vUserDelete({ version: '1.0', id: 'Me' });
+
+    result.match({
+      ok: () => {
+        // Account + Logto identity are gone server-side. Clear the local Logto session and lock out.
+        setState({ kind: 'deleted' });
+        window.location.assign(SIGN_OUT_HREF);
+      },
+      err: (problem: Problem) => {
+        if (problem.status === 409) {
+          const { detail, amount } = formatDebt(problem);
+          setState({ kind: 'debt', detail, amount });
+          return;
+        }
+        problemReporter.pushError(new Error(problem.title || problem.type || 'Account deletion failed'), {
+          source: 'account-deletion/delete',
+          problem,
+        });
+        setState({ kind: 'error', detail: problem.detail || 'Something went wrong. Please try again.' });
+      },
+    });
+  };
+
+  return (
+    <>
+      <Head>
+        <title>Delete account - LazyTax</title>
+        <meta name="robots" content="noindex" />
+      </Head>
+
+      <div className="container mx-auto px-4 py-12 max-w-xl">
+        <Card className="border-red-200 dark:border-red-900/50">
+          <CardHeader className="space-y-3">
+            <div className="flex items-center gap-3">
+              <div className="p-2 rounded-full bg-red-100 dark:bg-red-900/30">
+                <ShieldX className="w-6 h-6 text-red-600 dark:text-red-400" />
+              </div>
+              <CardTitle className="text-2xl">Delete your account</CardTitle>
+            </div>
+            <CardDescription>
+              This permanently deletes your LazyTax account and sign-in. There is no grace period and it cannot be
+              undone.
+            </CardDescription>
+          </CardHeader>
+
+          <CardContent className="space-y-5">
+            {state.kind === 'deleted' ? (
+              <div className="flex items-start gap-3 rounded-lg border border-green-200 dark:border-green-900/50 bg-green-50 dark:bg-green-950/40 p-4">
+                <CheckCircle2 className="w-5 h-5 text-green-600 dark:text-green-400 mt-0.5 shrink-0" />
+                <div className="text-sm text-green-800 dark:text-green-200">
+                  Your account has been deleted. Signing you out…
+                </div>
+              </div>
+            ) : !authed ? (
+              <>
+                <p className="text-sm text-slate-600 dark:text-slate-400">
+                  To delete your account you first need to sign in, so we can confirm it&apos;s really you. You&apos;ll
+                  come right back here afterwards.
+                </p>
+                <Button variant="destructive" onClick={() => window.location.assign(SIGN_IN_HREF)} className="w-full">
+                  Sign in to continue
+                </Button>
+              </>
+            ) : (
+              <>
+                <div className="rounded-lg border border-red-200 dark:border-red-900/50 bg-red-50 dark:bg-red-950/30 p-4">
+                  <p className="text-sm font-medium text-red-800 dark:text-red-200">What gets deleted</p>
+                  <ul className="mt-2 list-disc pl-5 text-sm text-red-700 dark:text-red-300 space-y-1">
+                    <li>Your profile, habits, history, vacations and freeze balances</li>
+                    <li>Your payment details and settings</li>
+                    <li>Your sign-in — you will be permanently logged out</li>
+                  </ul>
+                  <p className="mt-2 text-xs text-red-600/80 dark:text-red-300/70">
+                    Past charity-donation records are kept for accounting, with your personal details removed.
+                  </p>
+                </div>
+
+                {state.kind === 'debt' && (
+                  <div className="flex items-start gap-3 rounded-lg border border-amber-300 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/40 p-4">
+                    <AlertTriangle className="w-5 h-5 text-amber-600 dark:text-amber-400 mt-0.5 shrink-0" />
+                    <div className="text-sm text-amber-800 dark:text-amber-200 space-y-2">
+                      <p>
+                        You can&apos;t delete your account while you have an outstanding debt
+                        {state.amount ? ` of ${state.amount}` : ''}. Please settle it first.
+                      </p>
+                      <Button variant="outline" size="sm" onClick={() => window.location.assign('/app')}>
+                        Go to my account to settle
+                      </Button>
+                    </div>
+                  </div>
+                )}
+
+                {state.kind === 'error' && (
+                  <div className="rounded-lg border border-red-300 dark:border-red-800 bg-red-50 dark:bg-red-950/40 p-3 text-sm text-red-700 dark:text-red-300">
+                    {state.detail}
+                  </div>
+                )}
+
+                <div className="space-y-2">
+                  <label htmlFor="confirm" className="text-sm text-slate-700 dark:text-slate-300">
+                    Type <span className="font-mono font-semibold">{CONFIRM_PHRASE}</span> to confirm
+                  </label>
+                  <Input
+                    id="confirm"
+                    value={confirmText}
+                    onChange={e => setConfirmText(e.target.value)}
+                    placeholder={CONFIRM_PHRASE}
+                    autoComplete="off"
+                    disabled={state.kind === 'deleting'}
+                  />
+                </div>
+
+                <Button variant="destructive" className="w-full" disabled={!canConfirm} onClick={handleDelete}>
+                  {state.kind === 'deleting' ? 'Deleting…' : 'Permanently delete my account'}
+                </Button>
+              </>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </>
+  );
+}
+
+export const getServerSideProps = withServerSideAtomi(
+  { ...buildTime, guard: 'public' },
+  async (context, { auth }): Promise<GetServerSidePropsResult<AccountDeletionProps>> => {
+    // guard:'public' so a half-onboarded user is NOT bounced to onboarding — anyone authenticated
+    // must be able to delete. We only need to know whether they're signed in.
+    const authed = await auth.retriever
+      .getClaims()
+      .map(x => x.value.isAuthed)
+      .unwrapOr(false);
+    return { props: { authed } };
+  },
+);

--- a/src/pages/api/logto/[action].ts
+++ b/src/pages/api/logto/[action].ts
@@ -1,6 +1,30 @@
 import { buildTime } from '@/adapters/external/core';
 import { withApiLogtoOnly } from '@/adapters/atomi/next';
 
-export default withApiLogtoOnly(buildTime, (req, res, auth) => {
+// Only a same-origin relative path (e.g. "/account-deletion") may be used as a post-sign-in
+// return target — never an absolute or protocol-relative URL — to avoid open-redirect abuse.
+function safeReturnPath(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  return /^\/(?![/\\])/.test(value) ? value : undefined;
+}
+
+export default withApiLogtoOnly(buildTime, (req, res, { client: auth, baseUrl }) => {
+  // When signing in with a same-origin `redirectBackUrl`, carry it through the Logto round-trip
+  // via `postRedirectUri` (the SDK persists it in the sign-in cookie and the callback redirects
+  // there) so flows like /account-deletion return the user to where they started. The origin is
+  // taken from the trusted configured app base URL — NOT request headers — so a spoofed Host /
+  // X-Forwarded-Host can neither poison the OAuth redirect_uri nor turn the return into an open
+  // redirect. Every other route — and a plain sign-in without the param — is unchanged.
+  if (req.query.action === 'sign-in') {
+    const returnPath = safeReturnPath(req.query.redirectBackUrl);
+    if (returnPath) {
+      const origin = new URL(baseUrl).origin;
+      auth.handleSignIn({
+        redirectUri: `${origin}/api/logto/sign-in-callback`,
+        postRedirectUri: `${origin}${returnPath}`,
+      })(req, res);
+      return;
+    }
+  }
   auth.handleAuthRoutes({ fetchUserInfo: true })(req, res);
 });


### PR DESCRIPTION
## What

A public web page to delete your account — Google Play requires this to work **without** the app (e.g. after uninstall).

`/account-deletion` (`guard: 'public'`):
- **Requires login but NOT onboarding** — any authenticated user can delete (even half-onboarded)
- Logged-out → Logto sign-in, then **returns to this page** (via `postRedirectUri`)
- **Type-to-confirm** (`DELETE`) irreversible confirmation
- Calls zinc **`DELETE /User/Me`** (`vUserDelete({ id: 'Me' })`)
- **409 debt-blocked** → surfaces the amount + "settle first", not a raw error
- On success → **signs out** (locked out)

Sign-in route (`/api/logto/sign-in`) now honors a same-origin `redirectBackUrl`:
- Carries it through the Logto round-trip via `postRedirectUri`
- Origin comes from the **trusted configured baseUrl**, NOT request headers — a spoofed `Host` / `X-Forwarded-Host` can't poison the redirect (no open-redirect)
- `withApiLogtoOnly` extended to expose `baseUrl` (this route is its only consumer)

## Depends on
- zinc **`DELETE /User/Me`** (AtomiCloud/alcohol.zinc#49) — merge/deploy that first; this page is a no-op without it

## Testing
- `tsc --noEmit` clean
- The zinc endpoint itself was verified end-to-end (sandbox + lapras) on #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)