### PR TITLE
fix: recognise self-delete 409 body + argon-style deletion UI

### DIFF
--- a/src/lib/problem/core/transformer.ts
+++ b/src/lib/problem/core/transformer.ts
@@ -259,6 +259,19 @@ class ProblemTransformer<T extends ProblemDefinitions> {
         responseBody = '';
       }
 
+      // Some generated clients (e.g. 204-returning DELETE endpoints) don't pre-parse error
+      // bodies, so a structured Problem arrives only as raw text. Parse it and, if it's a
+      // Problem, surface it directly — otherwise the real status/detail get buried under a
+      // generic `http_error` (status 418) with the whole JSON dumped into `detail`.
+      if (responseBody.trim()) {
+        try {
+          const parsedBody = JSON.parse(responseBody);
+          if (isProblem(parsedBody)) return this.enrichProblemWithIds(parsedBody);
+        } catch {
+          // Not JSON — fall through to the generic http_error problem below.
+        }
+      }
+
       // Report to error reporter
       const httpError = new Error(`Swagger HTTP ${status}: ${responseBody}`);
       this.reportError(httpError, {

--- a/src/pages/account-deletion.tsx
+++ b/src/pages/account-deletion.tsx
@@ -7,6 +7,9 @@ import { useSwaggerClients } from '@/adapters/external/Provider';
 import { useProblemReporter } from '@/adapters/problem-reporter/providers/hooks';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { SignInCTA } from '@/components/ui/sign-in-cta';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import type { Problem } from '@/lib/problem/core';
 import { AlertTriangle, ShieldX, CheckCircle2 } from 'lucide-react';
@@ -31,8 +34,11 @@ type DeleteState =
 
 function formatDebt(problem: Problem): { detail: string; amount?: string } {
   // The zinc `account_deletion_blocked` problem carries totalDebt + currency as extension members.
-  const totalDebt = problem.totalDebt;
-  const currency = typeof problem.currency === 'string' ? problem.currency : '';
+  // zinc nests them under `data`, so check there first, then fall back to top-level.
+  const data = (problem.data ?? problem) as Record<string, unknown>;
+  const totalDebt = data.totalDebt ?? problem.totalDebt;
+  const currency =
+    typeof data.currency === 'string' ? data.currency : typeof problem.currency === 'string' ? problem.currency : '';
   const amount =
     typeof totalDebt === 'number' || typeof totalDebt === 'string'
       ? `${totalDebt}${currency ? ` ${currency}` : ''}`
@@ -44,12 +50,13 @@ export default function AccountDeletionPage({ authed }: AccountDeletionProps) {
   const api = useSwaggerClients();
   const problemReporter = useProblemReporter();
   const [confirmText, setConfirmText] = useState('');
+  const [confirmOpen, setConfirmOpen] = useState(false);
   const [state, setState] = useState<DeleteState>({ kind: 'idle' });
 
-  const canConfirm = confirmText.trim().toUpperCase() === CONFIRM_PHRASE && state.kind !== 'deleting';
+  const phraseOk = confirmText.trim().toUpperCase() === CONFIRM_PHRASE;
+  const deleting = state.kind === 'deleting';
 
   const handleDelete = async () => {
-    if (!canConfirm) return;
     setState({ kind: 'deleting' });
 
     // DELETE /api/v1.0/User/Me — the SDK has no dedicated "Me" delete method, but vUserDelete builds
@@ -60,10 +67,12 @@ export default function AccountDeletionPage({ authed }: AccountDeletionProps) {
     result.match({
       ok: () => {
         // Account + Logto identity are gone server-side. Clear the local Logto session and lock out.
+        setConfirmOpen(false);
         setState({ kind: 'deleted' });
         window.location.assign(SIGN_OUT_HREF);
       },
       err: (problem: Problem) => {
+        setConfirmOpen(false);
         if (problem.status === 409) {
           const { detail, amount } = formatDebt(problem);
           setState({ kind: 'debt', detail, amount });
@@ -86,11 +95,11 @@ export default function AccountDeletionPage({ authed }: AccountDeletionProps) {
       </Head>
 
       <div className="container mx-auto px-4 py-12 max-w-xl">
-        <Card className="border-red-200 dark:border-red-900/50">
+        <Card className="border-destructive/30">
           <CardHeader className="space-y-3">
             <div className="flex items-center gap-3">
-              <div className="p-2 rounded-full bg-red-100 dark:bg-red-900/30">
-                <ShieldX className="w-6 h-6 text-red-600 dark:text-red-400" />
+              <div className="p-2 rounded-full bg-destructive/10">
+                <ShieldX className="w-6 h-6 text-destructive" />
               </div>
               <CardTitle className="text-2xl">Delete your account</CardTitle>
             </div>
@@ -102,59 +111,62 @@ export default function AccountDeletionPage({ authed }: AccountDeletionProps) {
 
           <CardContent className="space-y-5">
             {state.kind === 'deleted' ? (
-              <div className="flex items-start gap-3 rounded-lg border border-green-200 dark:border-green-900/50 bg-green-50 dark:bg-green-950/40 p-4">
-                <CheckCircle2 className="w-5 h-5 text-green-600 dark:text-green-400 mt-0.5 shrink-0" />
-                <div className="text-sm text-green-800 dark:text-green-200">
-                  Your account has been deleted. Signing you out…
-                </div>
-              </div>
+              <Alert>
+                <CheckCircle2 className="text-green-600 dark:text-green-400" />
+                <AlertTitle>Your account has been deleted</AlertTitle>
+                <AlertDescription>Signing you out…</AlertDescription>
+              </Alert>
             ) : !authed ? (
               <>
-                <p className="text-sm text-slate-600 dark:text-slate-400">
+                <p className="text-sm text-muted-foreground">
                   To delete your account you first need to sign in, so we can confirm it&apos;s really you. You&apos;ll
                   come right back here afterwards.
                 </p>
-                <Button variant="destructive" onClick={() => window.location.assign(SIGN_IN_HREF)} className="w-full">
+                <SignInCTA href={SIGN_IN_HREF} icon="arrow" className="w-full">
                   Sign in to continue
-                </Button>
+                </SignInCTA>
               </>
             ) : (
               <>
-                <div className="rounded-lg border border-red-200 dark:border-red-900/50 bg-red-50 dark:bg-red-950/30 p-4">
-                  <p className="text-sm font-medium text-red-800 dark:text-red-200">What gets deleted</p>
-                  <ul className="mt-2 list-disc pl-5 text-sm text-red-700 dark:text-red-300 space-y-1">
-                    <li>Your profile, habits, history, vacations and freeze balances</li>
-                    <li>Your payment details and settings</li>
-                    <li>Your sign-in — you will be permanently logged out</li>
-                  </ul>
-                  <p className="mt-2 text-xs text-red-600/80 dark:text-red-300/70">
-                    Past charity-donation records are kept for accounting, with your personal details removed.
-                  </p>
-                </div>
+                <Alert variant="destructive">
+                  <AlertTriangle />
+                  <AlertTitle>What gets deleted</AlertTitle>
+                  <AlertDescription>
+                    <ul className="list-disc pl-5 space-y-1">
+                      <li>Your profile, habits, history, vacations and freeze balances</li>
+                      <li>Your payment details and settings</li>
+                      <li>Your sign-in — you will be permanently logged out</li>
+                    </ul>
+                    <p className="mt-2 text-xs">
+                      Past charity-donation records are kept for accounting, with your personal details removed.
+                    </p>
+                  </AlertDescription>
+                </Alert>
 
                 {state.kind === 'debt' && (
-                  <div className="flex items-start gap-3 rounded-lg border border-amber-300 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/40 p-4">
-                    <AlertTriangle className="w-5 h-5 text-amber-600 dark:text-amber-400 mt-0.5 shrink-0" />
-                    <div className="text-sm text-amber-800 dark:text-amber-200 space-y-2">
+                  <Alert>
+                    <AlertTriangle className="text-amber-600 dark:text-amber-400" />
+                    <AlertTitle>Settle your outstanding debt first</AlertTitle>
+                    <AlertDescription>
                       <p>
                         You can&apos;t delete your account while you have an outstanding debt
-                        {state.amount ? ` of ${state.amount}` : ''}. Please settle it first.
+                        {state.amount ? ` of ${state.amount}` : ''}. It&apos;s collected automatically at the end of the
+                        month — once it&apos;s cleared, you can delete your account here.
                       </p>
-                      <Button variant="outline" size="sm" onClick={() => window.location.assign('/app')}>
-                        Go to my account to settle
-                      </Button>
-                    </div>
-                  </div>
+                    </AlertDescription>
+                  </Alert>
                 )}
 
                 {state.kind === 'error' && (
-                  <div className="rounded-lg border border-red-300 dark:border-red-800 bg-red-50 dark:bg-red-950/40 p-3 text-sm text-red-700 dark:text-red-300">
-                    {state.detail}
-                  </div>
+                  <Alert variant="destructive">
+                    <AlertTriangle />
+                    <AlertTitle>Account deletion failed</AlertTitle>
+                    <AlertDescription>{state.detail}</AlertDescription>
+                  </Alert>
                 )}
 
                 <div className="space-y-2">
-                  <label htmlFor="confirm" className="text-sm text-slate-700 dark:text-slate-300">
+                  <label htmlFor="confirm" className="text-sm text-muted-foreground">
                     Type <span className="font-mono font-semibold">{CONFIRM_PHRASE}</span> to confirm
                   </label>
                   <Input
@@ -163,13 +175,36 @@ export default function AccountDeletionPage({ authed }: AccountDeletionProps) {
                     onChange={e => setConfirmText(e.target.value)}
                     placeholder={CONFIRM_PHRASE}
                     autoComplete="off"
-                    disabled={state.kind === 'deleting'}
+                    disabled={deleting}
                   />
                 </div>
 
-                <Button variant="destructive" className="w-full" disabled={!canConfirm} onClick={handleDelete}>
-                  {state.kind === 'deleting' ? 'Deleting…' : 'Permanently delete my account'}
+                <Button
+                  variant="destructive"
+                  className="w-full"
+                  disabled={!phraseOk || deleting}
+                  onClick={() => setConfirmOpen(true)}
+                >
+                  Permanently delete my account
                 </Button>
+
+                <ConfirmDialog
+                  open={confirmOpen}
+                  onOpenChange={setConfirmOpen}
+                  onCancel={() => setConfirmOpen(false)}
+                  onConfirm={handleDelete}
+                  loading={deleting}
+                  confirmLabel={deleting ? 'Deleting…' : 'Yes, delete forever'}
+                  cancelLabel="Keep my account"
+                  confirmVariant="destructive"
+                  title="Delete your account permanently?"
+                  description={
+                    <span>
+                      This removes your profile, habits, payment details and sign-in. It happens immediately and
+                      <strong> cannot be undone.</strong>
+                    </span>
+                  }
+                />
               </>
             )}
           </CardContent>


### PR DESCRIPTION
Follow-up to #91. Fixes how the account-deletion page surfaces the debt-block (and any zinc problem) and aligns the page with argon's design system.

## Problem
`DELETE /User/Me` returns **204** on success, so its generated SDK method has no `format: json` and swagger-typescript-api never parses the **error** body. A `409 account_deletion_blocked` therefore fell back to a generic `http_error` (status **418**) with the whole JSON dumped into `detail` — which rendered as a raw, overflowing error blob (looked like a bug; it's actually the expected debt-block).

## Changes
- **`transformer.ts`** — in `fromSwaggerError`, `JSON.parse` the raw text body and, if it's a `Problem`, surface it directly (mirrors `fromHttpResponse`). The real 409 + detail now reach the page. Benefits **all** 204-returning endpoints, not just this one.
- **`account-deletion.tsx`**
  - Rebuilt on argon's own components — `Alert` / `ConfirmDialog` / `SignInCTA` — instead of bespoke coloured divs. Delete now goes through the standard confirmation popup (same idiom as settings' "remove consent").
  - Read `totalDebt`/`currency` from the nested `data` member so the amount shows.
  - Debt is **expected** (anti-dodge), not an error: the blocked panel explains it clears automatically end-of-month. Removed the "settle now" button — **no manual settle flow exists yet** (no zinc endpoint / argon UI).

## Verification
- Deployed to **pichu** and re-tested live: debt-block now renders as a clean amber `Alert` ("Settle your outstanding debt first … 120 USD"), not raw JSON.
- `tsc` + biome + treefmt + gitlint all green (pre-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error response parsing to better handle error identification.

* **New Features**
  * Enhanced account deletion interface with modal confirmation dialog requiring phrase verification.
  * Added confirmation alerts and authentication prompts to deletion workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->