### PR TITLE
fix: unblock semantic-release npm install via legacy-peer-deps

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
Fixes the broken **release pipeline** so tags get cut and CD can deploy argon to pikachu/raichu.

## Problem
The release job's npm-based `semantic-release` install fails with **ERESOLVE**:
- npm re-resolves `@opennextjs/cloudflare@^1.5.1` → **1.19.11**, whose peer `next@>=15.5.18` conflicts with the pinned **`next@15.3.4`**
- The app builds fine via **bun** (lenient peers); only the **npm** step in the release job is strict → no tag → CD never runs

(Observed in the Release run after #91 merged: `npm error code ERESOLVE … peer next@">=15.5.18" from @opennextjs/cloudflare@1.19.11`.)

## Fix
Add root `.npmrc`:
```
legacy-peer-deps=true
```
- Affects **only npm** (the semantic-release installer) — bun + the opennext build are untouched
- The release job doesn't build the app, so a tolerated peer mismatch there is inert
- Minimal blast radius; no app dependency changes

## Follow-up (not in this PR)
Properly realign `@opennextjs/cloudflare` vs `next` (pin opennext to a 15.3.x-compatible version, or bump next) so the float can't drift again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)