### PR TITLE
feat: web checkout + subscription management portal

### DIFF
--- a/src/clients/alcohol/zinc/api.ts
+++ b/src/clients/alcohol/zinc/api.ts
@@ -69,6 +69,10 @@ export interface CauseRes {
   principal: CausePrincipalRes;
 }
 
+export interface ChangeTierReq {
+  tier?: string | null;
+}
+
 export interface CharityPrincipalRes {
   id?: string | null;
   name?: string | null;
@@ -311,6 +315,11 @@ export interface ProtectionBalanceRes {
   cap: number;
 }
 
+export interface RunDisbursementRes {
+  /** @format int32 */
+  completed: number;
+}
+
 export interface SetCharityCausesReq {
   keys?: string[] | null;
 }
@@ -323,6 +332,20 @@ export interface StakeRes {
   /** @format double */
   amount: number;
   currency?: string | null;
+}
+
+export interface SubscribeReq {
+  tier?: string | null;
+}
+
+export interface SubscriptionRes {
+  userId?: string | null;
+  tier?: string | null;
+  status?: string | null;
+  periodStart?: string | null;
+  periodEnd?: string | null;
+  cancelAtPeriodEnd: boolean;
+  nextTier?: string | null;
 }
 
 export interface UpdateCauseReq {
@@ -626,6 +649,16 @@ export interface VConfigurationCreate2Params {
 
 export type VConfigurationCreate2Data = ConfigurationPrincipalRes;
 
+export interface VDisbursementRunCreateParams {
+  /**
+   * The requested API version
+   * @default "1.0"
+   */
+  version: string;
+}
+
+export type VDisbursementRunCreateData = RunDisbursementRes;
+
 export interface VEmailCreateParams {
   to: string;
   /**
@@ -895,6 +928,50 @@ export interface VProtectionAwardWeeklyCreateParams {
 
 export type VProtectionAwardWeeklyCreateData = AwardWeeklyRes;
 
+export interface VSubscriptionDetailParams {
+  userId: string;
+  /**
+   * The requested API version
+   * @default "1.0"
+   */
+  version: string;
+}
+
+export type VSubscriptionDetailData = SubscriptionRes;
+
+export interface VSubscriptionSubscribeCreateParams {
+  userId: string;
+  /**
+   * The requested API version
+   * @default "1.0"
+   */
+  version: string;
+}
+
+export type VSubscriptionSubscribeCreateData = SubscriptionRes;
+
+export interface VSubscriptionCancelCreateParams {
+  userId: string;
+  /**
+   * The requested API version
+   * @default "1.0"
+   */
+  version: string;
+}
+
+export type VSubscriptionCancelCreateData = SubscriptionRes;
+
+export interface VSubscriptionChangeTierCreateParams {
+  userId: string;
+  /**
+   * The requested API version
+   * @default "1.0"
+   */
+  version: string;
+}
+
+export type VSubscriptionChangeTierCreateData = SubscriptionRes;
+
 export type GetRootData = Info;
 
 export interface VUserListParams {
@@ -935,6 +1012,16 @@ export interface VUserMeListParams {
 }
 
 export type VUserMeListData = string;
+
+export interface VUserMeDeleteParams {
+  /**
+   * The requested API version
+   * @default "1.0"
+   */
+  version: string;
+}
+
+export type VUserMeDeleteData = any;
 
 export interface VUserMeAllListParams {
   /**
@@ -1284,7 +1371,7 @@ export class HttpClient<SecurityDataType = unknown> {
 }
 
 /**
- * @title Lapras Alcohol Zinc API
+ * @title Pichu Alcohol Zinc API
  * @version 1.0
  * @contact kirinnee <kirinnee97@gmail.com>
  *
@@ -1698,6 +1785,24 @@ export class AlcoholZincApi<SecurityDataType extends unknown> extends HttpClient
         body: data,
         secure: true,
         type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Disbursement
+     * @name VDisbursementRunCreate
+     * @request POST:/api/v{version}/disbursement/run
+     * @secure
+     * @response `200` `VDisbursementRunCreateData` Success
+     */
+    vDisbursementRunCreate: ({ version, ...query }: VDisbursementRunCreateParams, params: RequestParams = {}) =>
+      this.request<VDisbursementRunCreateData, any>({
+        path: `/api/v${version}/disbursement/run`,
+        method: 'POST',
+        secure: true,
         format: 'json',
         ...params,
       }),
@@ -2167,6 +2272,93 @@ export class AlcoholZincApi<SecurityDataType extends unknown> extends HttpClient
     /**
      * No description
      *
+     * @tags Subscription
+     * @name VSubscriptionDetail
+     * @request GET:/api/v{version}/Subscription/{userId}
+     * @secure
+     * @response `200` `VSubscriptionDetailData` Success
+     */
+    vSubscriptionDetail: ({ userId, version, ...query }: VSubscriptionDetailParams, params: RequestParams = {}) =>
+      this.request<VSubscriptionDetailData, any>({
+        path: `/api/v${version}/Subscription/${userId}`,
+        method: 'GET',
+        secure: true,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Subscription
+     * @name VSubscriptionSubscribeCreate
+     * @request POST:/api/v{version}/Subscription/{userId}/subscribe
+     * @secure
+     * @response `200` `VSubscriptionSubscribeCreateData` Success
+     */
+    vSubscriptionSubscribeCreate: (
+      { userId, version, ...query }: VSubscriptionSubscribeCreateParams,
+      data: SubscribeReq,
+      params: RequestParams = {},
+    ) =>
+      this.request<VSubscriptionSubscribeCreateData, any>({
+        path: `/api/v${version}/Subscription/${userId}/subscribe`,
+        method: 'POST',
+        body: data,
+        secure: true,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Subscription
+     * @name VSubscriptionCancelCreate
+     * @request POST:/api/v{version}/Subscription/{userId}/cancel
+     * @secure
+     * @response `200` `VSubscriptionCancelCreateData` Success
+     */
+    vSubscriptionCancelCreate: (
+      { userId, version, ...query }: VSubscriptionCancelCreateParams,
+      params: RequestParams = {},
+    ) =>
+      this.request<VSubscriptionCancelCreateData, any>({
+        path: `/api/v${version}/Subscription/${userId}/cancel`,
+        method: 'POST',
+        secure: true,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Subscription
+     * @name VSubscriptionChangeTierCreate
+     * @request POST:/api/v{version}/Subscription/{userId}/change-tier
+     * @secure
+     * @response `200` `VSubscriptionChangeTierCreateData` Success
+     */
+    vSubscriptionChangeTierCreate: (
+      { userId, version, ...query }: VSubscriptionChangeTierCreateParams,
+      data: ChangeTierReq,
+      params: RequestParams = {},
+    ) =>
+      this.request<VSubscriptionChangeTierCreateData, any>({
+        path: `/api/v${version}/Subscription/${userId}/change-tier`,
+        method: 'POST',
+        body: data,
+        secure: true,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
      * @tags User
      * @name VUserList
      * @request GET:/api/v{version}/User
@@ -2216,6 +2408,23 @@ export class AlcoholZincApi<SecurityDataType extends unknown> extends HttpClient
       this.request<VUserMeListData, any>({
         path: `/api/v${version}/User/Me`,
         method: 'GET',
+        secure: true,
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags User
+     * @name VUserMeDelete
+     * @request DELETE:/api/v{version}/User/Me
+     * @secure
+     * @response `200` `VUserMeDeleteData` Success
+     */
+    vUserMeDelete: ({ version, ...query }: VUserMeDeleteParams, params: RequestParams = {}) =>
+      this.request<VUserMeDeleteData, any>({
+        path: `/api/v${version}/User/Me`,
+        method: 'DELETE',
         secure: true,
         ...params,
       }),

--- a/src/clients/alcohol/zinc/api.ts
+++ b/src/clients/alcohol/zinc/api.ts
@@ -843,6 +843,7 @@ export interface VPaymentClientSecretListParams {
 export type VPaymentClientSecretListData = ClientSecretRes;
 
 export interface VPaymentConsentListParams {
+  purpose?: string;
   userId: string;
   /**
    * The requested API version
@@ -854,6 +855,7 @@ export interface VPaymentConsentListParams {
 export type VPaymentConsentListData = PaymentConsentRes;
 
 export interface VPaymentConsentDeleteParams {
+  purpose?: string;
   userId: string;
   /**
    * The requested API version
@@ -2114,6 +2116,7 @@ export class AlcoholZincApi<SecurityDataType extends unknown> extends HttpClient
       this.request<VPaymentConsentListData, any>({
         path: `/api/v${version}/Payment/${userId}/consent`,
         method: 'GET',
+        query: query,
         secure: true,
         format: 'json',
         ...params,
@@ -2132,6 +2135,7 @@ export class AlcoholZincApi<SecurityDataType extends unknown> extends HttpClient
       this.request<VPaymentConsentDeleteData, any>({
         path: `/api/v${version}/Payment/${userId}/consent`,
         method: 'DELETE',
+        query: query,
         secure: true,
         ...params,
       }),

--- a/src/components/landing/Pricing.tsx
+++ b/src/components/landing/Pricing.tsx
@@ -1,4 +1,6 @@
 import { useState } from 'react';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { HelpCircle } from 'lucide-react';
 import Image from 'next/image';
@@ -107,11 +109,13 @@ export default function Pricing() {
                 </div>
               </CardTitle>
               <CardDescription>Pro — Everything in Free, plus:</CardDescription>
-              <div className="text-[11px] text-violet-700 dark:text-violet-300 mt-1">
-                Launch exclusive: we’ll let you lock in this price when plans open.
-              </div>
+              {period === 'annual' && (
+                <div className="text-[11px] text-violet-700 dark:text-violet-300 mt-1">
+                  Annual billing coming soon — billed monthly at launch prices for now.
+                </div>
+              )}
             </CardHeader>
-            <CardContent className="text-slate-700 dark:text-slate-300 mt-auto opacity-60">
+            <CardContent className="text-slate-700 dark:text-slate-300 mt-auto">
               <ul className="list-disc pl-5 space-y-1.5 text-sm">
                 <li>Up to 10 habits</li>
                 <li>
@@ -151,15 +155,10 @@ export default function Pricing() {
                   </span>
                 </li>
               </ul>
+              <Button asChild className="mt-4 w-full bg-violet-600 hover:bg-violet-700 text-white">
+                <Link href="/billing/checkout?tier=pro">Get Pro</Link>
+              </Button>
             </CardContent>
-            {/* Coming Soon overlay for Pro */}
-            <div
-              className="pointer-events-auto absolute inset-0 z-10 bg-black/60 backdrop-blur-[2px] rounded-xl flex items-center justify-center cursor-not-allowed"
-              aria-label="Pro plan coming soon"
-              role="presentation"
-            >
-              <span className="text-white/90 font-semibold text-sm tracking-wide uppercase">Coming soon</span>
-            </div>
           </Card>
           {/* Ultimate card in same grid */}
           <Card className="relative border-amber-300 dark:border-amber-900/40 bg-gradient-to-b from-amber-500/10 to-transparent shadow-lg h-full flex flex-col">
@@ -185,11 +184,13 @@ export default function Pricing() {
                 </div>
               </CardTitle>
               <CardDescription>Ultimate — Everything in Pro, plus:</CardDescription>
-              <div className="text-[11px] text-amber-700 dark:text-amber-300 mt-1">
-                Launch exclusive: we’ll let you lock in this price when plans open.
-              </div>
+              {period === 'annual' && (
+                <div className="text-[11px] text-amber-700 dark:text-amber-300 mt-1">
+                  Annual billing coming soon — billed monthly at launch prices for now.
+                </div>
+              )}
             </CardHeader>
-            <CardContent className="text-slate-700 dark:text-slate-300 mt-auto opacity-60">
+            <CardContent className="text-slate-700 dark:text-slate-300 mt-auto">
               <ul className="list-disc pl-5 space-y-1.5 text-sm">
                 <li>Unlimited habits</li>
                 <li>
@@ -228,15 +229,10 @@ export default function Pricing() {
                 <li>We donate USD $15 at 100 days</li>
                 <li>Priority support</li>
               </ul>
+              <Button asChild className="mt-4 w-full bg-amber-600 hover:bg-amber-700 text-white">
+                <Link href="/billing/checkout?tier=ultimate">Get Ultimate</Link>
+              </Button>
             </CardContent>
-            {/* Coming Soon overlay for Ultimate */}
-            <div
-              className="pointer-events-auto absolute inset-0 z-10 bg-black/60 backdrop-blur-[2px] rounded-xl flex items-center justify-center cursor-not-allowed"
-              aria-label="Ultimate plan coming soon"
-              role="presentation"
-            >
-              <span className="text-white/90 font-semibold text-sm tracking-wide uppercase">Coming soon</span>
-            </div>
           </Card>
         </div>
 

--- a/src/lib/billing/errors.ts
+++ b/src/lib/billing/errors.ts
@@ -1,0 +1,51 @@
+import type { Problem } from '@/lib/problem/core';
+
+export type BillingErrorKind =
+  | 'no_payment_consent'
+  | 'subscription_charge_failed'
+  | 'renewal_in_progress'
+  | 'already_subscribed'
+  | 'invalid_subscription_tier'
+  | 'no_active_subscription'
+  | 'unknown';
+
+// zinc problems pass through the swagger adapter verbatim; the machine code is
+// the last segment of the RFC 7807 `type` URI
+// (e.g. https://api.zinc.../docs/.../v1/no_payment_consent).
+export function zincErrorId(problem: Problem): string | null {
+  if (typeof problem.type !== 'string' || problem.type.length === 0) return null;
+  return problem.type.split('/').filter(Boolean).pop() ?? null;
+}
+
+const KNOWN_IDS: ReadonlySet<string> = new Set([
+  'no_payment_consent',
+  'subscription_charge_failed',
+  'renewal_in_progress',
+  'already_subscribed',
+  'invalid_subscription_tier',
+  'no_active_subscription',
+]);
+
+export function classifyBillingError(problem: Problem): BillingErrorKind {
+  const id = zincErrorId(problem);
+  if (id && KNOWN_IDS.has(id)) return id as BillingErrorKind;
+
+  // Fallback on HTTP status when the type URI is unavailable or unrecognized.
+  switch (problem.status) {
+    case 412:
+      return 'no_payment_consent';
+    case 402:
+      return 'subscription_charge_failed';
+    case 409:
+      return 'renewal_in_progress';
+    default:
+      return 'unknown';
+  }
+}
+
+// subscription_charge_failed carries the Airwallex intent status as a
+// Problem extension field.
+export function chargeFailureIntentStatus(problem: Problem): string | null {
+  const status = problem.intentStatus;
+  return typeof status === 'string' && status.length > 0 ? status : null;
+}

--- a/src/lib/billing/pricing.ts
+++ b/src/lib/billing/pricing.ts
@@ -1,0 +1,39 @@
+export type PaidTier = 'pro' | 'ultimate';
+export type Tier = 'free' | PaidTier;
+
+export interface TierPricing {
+  label: string;
+  /** Launch price actually charged, in USD cents */
+  launchCents: number;
+  /** Struck-through original price, in USD cents */
+  originalCents: number;
+}
+
+// Monthly billing only — zinc has no annual billing. Keep in sync with
+// alcohol.zinc App/Config/settings.yaml (Subscription.Tiers PriceCents).
+export const TIER_PRICING: Record<PaidTier, TierPricing> = {
+  pro: { label: 'Pro', launchCents: 499, originalCents: 999 },
+  ultimate: { label: 'Ultimate', launchCents: 799, originalCents: 1499 },
+};
+
+// Rank ordering decides upgrade (immediate charge, period resets) vs
+// downgrade (applies at period end) messaging.
+export const TIER_RANK: Record<Tier, number> = { free: 0, pro: 1, ultimate: 2 };
+
+export function parsePaidTier(value: unknown): PaidTier | null {
+  return value === 'pro' || value === 'ultimate' ? value : null;
+}
+
+export function parseTier(value: unknown): Tier | null {
+  return value === 'free' ? 'free' : parsePaidTier(value);
+}
+
+export function formatUsdCents(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+export function tierLabel(tier: string | null | undefined): string {
+  const parsed = parseTier(tier);
+  if (parsed === 'free' || parsed == null) return 'Free';
+  return TIER_PRICING[parsed].label;
+}

--- a/src/lib/billing/use-subscription.ts
+++ b/src/lib/billing/use-subscription.ts
@@ -1,0 +1,61 @@
+import { useCallback } from 'react';
+import { useSwaggerClients } from '@/adapters/external/Provider';
+import type { SubscriptionRes } from '@/clients/alcohol/zinc/api';
+import { useUserId } from '@/lib/auth/use-user';
+import type { Result } from '@/lib/monads/result';
+import { Err } from '@/lib/monads/result';
+import type { Problem } from '@/lib/problem/core';
+import type { PaidTier, Tier } from '@/lib/billing/pricing';
+
+function notSignedInProblem(): Problem {
+  return {
+    type: 'about:blank',
+    title: 'Not signed in',
+    status: 401,
+    detail: 'Your session is not ready yet. Please try again.',
+  };
+}
+
+export interface UseSubscriptionActions {
+  /** Subscribe to a paid tier (charges immediately). */
+  subscribe: (tier: PaidTier) => Promise<Result<SubscriptionRes, Problem>>;
+  /** Stop renewal at period end; access is retained until then. */
+  cancel: () => Promise<Result<SubscriptionRes, Problem>>;
+  /** Upgrade (immediate charge, period resets) or downgrade (applies at period end). */
+  changeTier: (tier: Tier) => Promise<Result<SubscriptionRes, Problem>>;
+  /**
+   * Undo a pending cancel-at-period-end: zinc has no dedicated un-cancel
+   * endpoint — re-subscribing to the current tier flips the flag free of charge.
+   */
+  unCancel: (currentTier: PaidTier) => Promise<Result<SubscriptionRes, Problem>>;
+}
+
+export function useSubscription(): UseSubscriptionActions {
+  const api = useSwaggerClients();
+  const userId = useUserId();
+
+  const subscribe = useCallback(
+    async (tier: PaidTier): Promise<Result<SubscriptionRes, Problem>> => {
+      if (!userId) return Err(notSignedInProblem());
+      return api.alcohol.zinc.api.vSubscriptionSubscribeCreate({ version: '1.0', userId }, { tier });
+    },
+    [api, userId],
+  );
+
+  const cancel = useCallback(async (): Promise<Result<SubscriptionRes, Problem>> => {
+    if (!userId) return Err(notSignedInProblem());
+    return api.alcohol.zinc.api.vSubscriptionCancelCreate({ version: '1.0', userId });
+  }, [api, userId]);
+
+  const changeTier = useCallback(
+    async (tier: Tier): Promise<Result<SubscriptionRes, Problem>> => {
+      if (!userId) return Err(notSignedInProblem());
+      return api.alcohol.zinc.api.vSubscriptionChangeTierCreate({ version: '1.0', userId }, { tier });
+    },
+    [api, userId],
+  );
+
+  const unCancel = useCallback((currentTier: PaidTier) => subscribe(currentTier), [subscribe]);
+
+  return { subscribe, cancel, changeTier, unCancel };
+}

--- a/src/lib/billing/use-subscription.ts
+++ b/src/lib/billing/use-subscription.ts
@@ -1,20 +1,11 @@
 import { useCallback } from 'react';
-import { useSwaggerClients } from '@/adapters/external/Provider';
+import { useProblemRegistry, useSwaggerClients } from '@/adapters/external/Provider';
 import type { SubscriptionRes } from '@/clients/alcohol/zinc/api';
 import { useUserId } from '@/lib/auth/use-user';
 import type { Result } from '@/lib/monads/result';
 import { Err } from '@/lib/monads/result';
 import type { Problem } from '@/lib/problem/core';
 import type { PaidTier, Tier } from '@/lib/billing/pricing';
-
-function notSignedInProblem(): Problem {
-  return {
-    type: 'about:blank',
-    title: 'Not signed in',
-    status: 401,
-    detail: 'Your session is not ready yet. Please try again.',
-  };
-}
 
 export interface UseSubscriptionActions {
   /** Subscribe to a paid tier (charges immediately). */
@@ -33,26 +24,29 @@ export interface UseSubscriptionActions {
 export function useSubscription(): UseSubscriptionActions {
   const api = useSwaggerClients();
   const userId = useUserId();
+  const problemRegistry = useProblemRegistry();
+
+  const notSignedIn = useCallback((): Problem => problemRegistry.createProblem('unauthorized', {}), [problemRegistry]);
 
   const subscribe = useCallback(
     async (tier: PaidTier): Promise<Result<SubscriptionRes, Problem>> => {
-      if (!userId) return Err(notSignedInProblem());
+      if (!userId) return Err(notSignedIn());
       return api.alcohol.zinc.api.vSubscriptionSubscribeCreate({ version: '1.0', userId }, { tier });
     },
-    [api, userId],
+    [api, userId, notSignedIn],
   );
 
   const cancel = useCallback(async (): Promise<Result<SubscriptionRes, Problem>> => {
-    if (!userId) return Err(notSignedInProblem());
+    if (!userId) return Err(notSignedIn());
     return api.alcohol.zinc.api.vSubscriptionCancelCreate({ version: '1.0', userId });
-  }, [api, userId]);
+  }, [api, userId, notSignedIn]);
 
   const changeTier = useCallback(
     async (tier: Tier): Promise<Result<SubscriptionRes, Problem>> => {
-      if (!userId) return Err(notSignedInProblem());
+      if (!userId) return Err(notSignedIn());
       return api.alcohol.zinc.api.vSubscriptionChangeTierCreate({ version: '1.0', userId }, { tier });
     },
-    [api, userId],
+    [api, userId, notSignedIn],
   );
 
   const unCancel = useCallback((currentTier: PaidTier) => subscribe(currentTier), [subscribe]);

--- a/src/lib/payment/use-payment-consent.ts
+++ b/src/lib/payment/use-payment-consent.ts
@@ -128,9 +128,10 @@ export function usePaymentConsent(options?: UsePaymentConsentOptions): UsePaymen
           recurringOptions: {
             next_triggered_by: 'merchant',
             currency: 'USD',
+            // Airwallex MIT reasons: scheduled | unscheduled | installments.
             // zinc's webhook classifies the consent's purpose from this reason:
-            // 'recurring' → subscription consent, 'unscheduled' → penalty consent.
-            merchant_trigger_reason: purpose === 'subscription' ? 'recurring' : 'unscheduled',
+            // 'scheduled' → subscription consent, anything else → penalty consent.
+            merchant_trigger_reason: purpose === 'subscription' ? 'scheduled' : 'unscheduled',
           },
           logoUrl: 'https://lazytax.club/logo-source.svg',
           successUrl: callbackUrl,

--- a/src/lib/payment/use-payment-consent.ts
+++ b/src/lib/payment/use-payment-consent.ts
@@ -1,9 +1,32 @@
 import { useCallback, useState } from 'react';
 import { useClientConfig, useCommonConfig, useSwaggerClients } from '@/adapters/external/Provider';
-import type { ClientSecretRes, CreateCustomerRes, PaymentConsentRes } from '@/clients/alcohol/zinc/api';
+import type {
+  ClientSecretRes,
+  CreateCustomerRes,
+  PaymentConsentRes,
+  VPaymentConsentListParams,
+} from '@/clients/alcohol/zinc/api';
 import { init } from '@airwallex/components-sdk';
 import { useTheme } from '@/lib/theme/provider';
 import { useHasPaymentConsent, useUserId } from '@/lib/auth/use-user';
+
+/**
+ * Which charging relationship the consent authorizes, mirroring zinc's
+ * purpose-scoped consents (card-network MIT classification):
+ *  - 'penalty'      → unscheduled merchant-initiated (stakes/donations)
+ *  - 'subscription' → recurring merchant-initiated (plan renewals)
+ */
+export type ConsentPurpose = 'penalty' | 'subscription';
+
+// zinc's `purpose` query param on the consent endpoints ships with the
+// separate-consents work; until that deploys to pichu the generated params
+// type lacks it. The generated methods spread `...query`, so passing it is
+// runtime-safe today. Drop this cast after the next SDK regen.
+type WithPurpose<T> = T & { purpose?: ConsentPurpose };
+
+interface UsePaymentConsentOptions {
+  purpose?: ConsentPurpose;
+}
 
 interface UsePaymentConsentReturn {
   /**
@@ -26,8 +49,15 @@ interface UsePaymentConsentReturn {
 
 /**
  * Hook to handle payment consent flow with Airwallex
+ *
+ * Defaults to the penalty (unscheduled) consent, preserving the original
+ * behavior for stakes/donations. Pass `{ purpose: 'subscription' }` for the
+ * recurring consent used by plan billing — that variant never consults the
+ * Logto `has_payment_consent` claim (the claim tracks the penalty consent
+ * only) and always checks zinc directly.
  */
-export function usePaymentConsent(): UsePaymentConsentReturn {
+export function usePaymentConsent(options?: UsePaymentConsentOptions): UsePaymentConsentReturn {
+  const purpose: ConsentPurpose = options?.purpose ?? 'penalty';
   const api = useSwaggerClients();
   const [checking, setChecking] = useState(false);
   const clientConfig = useClientConfig();
@@ -38,8 +68,8 @@ export function usePaymentConsent(): UsePaymentConsentReturn {
 
   const checkAndInitiatePayment = useCallback(
     async (onSuccess: () => void, returnUrl: string) => {
-      // Check if user already has consent
-      if (hasConsent) {
+      // The Logto claim shortcut only reflects the penalty consent.
+      if (purpose === 'penalty' && hasConsent) {
         onSuccess();
         return;
       }
@@ -49,6 +79,21 @@ export function usePaymentConsent(): UsePaymentConsentReturn {
         // Get userId from claims (no API call needed)
         if (!userId) {
           throw new Error('User ID not available');
+        }
+
+        if (purpose === 'subscription') {
+          // No claim tracks the subscription consent — ask zinc directly.
+          const consentResult = await api.alcohol.zinc.api.vPaymentConsentList({
+            version: '1.0',
+            userId,
+            purpose,
+          } as WithPurpose<VPaymentConsentListParams>);
+          const consentData: PaymentConsentRes = await consentResult.unwrap();
+          if (consentData.hasPaymentConsent) {
+            setChecking(false);
+            onSuccess();
+            return;
+          }
         }
 
         // Create customer (idempotent)
@@ -81,7 +126,7 @@ export function usePaymentConsent(): UsePaymentConsentReturn {
         // Redirect to Airwallex HPP
         // After payment, user will be redirected to callback page which handles polling and token refresh
         const encodedReturnUrl = encodeURIComponent(returnUrl);
-        const callbackUrl = `${window.location.origin}/app/payment/callback?payment_status=success&return_url=${encodedReturnUrl}`;
+        const callbackUrl = `${window.location.origin}/app/payment/callback?payment_status=success&purpose=${purpose}&return_url=${encodedReturnUrl}`;
 
         payments?.redirectToCheckout({
           env: clientConfig.payment.airwallex.env,
@@ -98,7 +143,9 @@ export function usePaymentConsent(): UsePaymentConsentReturn {
           recurringOptions: {
             next_triggered_by: 'merchant',
             currency: 'USD',
-            merchant_trigger_reason: 'unscheduled',
+            // zinc's webhook classifies the consent's purpose from this reason:
+            // 'recurring' → subscription consent, 'unscheduled' → penalty consent.
+            merchant_trigger_reason: purpose === 'subscription' ? 'recurring' : 'unscheduled',
           },
           logoUrl: 'https://lazytax.club/logo-source.svg',
           successUrl: callbackUrl,
@@ -109,7 +156,7 @@ export function usePaymentConsent(): UsePaymentConsentReturn {
         throw error;
       }
     },
-    [api, hasConsent, userId, clientConfig.payment.airwallex.env, theme.theme, commonConfig.pwa.themeColor],
+    [api, purpose, hasConsent, userId, clientConfig.payment.airwallex.env, theme.theme, commonConfig.pwa.themeColor],
   );
 
   const pollPaymentConsent = useCallback(
@@ -133,12 +180,19 @@ export function usePaymentConsent(): UsePaymentConsentReturn {
           attempts++;
 
           try {
-            const consentResult = await api.alcohol.zinc.api.vPaymentConsentList({ version: '1.0', userId });
+            const consentResult = await api.alcohol.zinc.api.vPaymentConsentList({
+              version: '1.0',
+              userId,
+              purpose,
+            } as WithPurpose<VPaymentConsentListParams>);
             const consentData: PaymentConsentRes = await consentResult.unwrap();
 
             if (consentData.hasPaymentConsent) {
-              // Success! Refresh tokens to get updated claims
-              await fetch('/api/auth/force_tokens');
+              if (purpose === 'penalty') {
+                // Success! Refresh tokens to get updated claims (penalty consent only —
+                // no Logto claim tracks the subscription consent).
+                await fetch('/api/auth/force_tokens');
+              }
               onSuccess();
               return;
             }
@@ -170,7 +224,7 @@ export function usePaymentConsent(): UsePaymentConsentReturn {
         onError();
       }
     },
-    [api, userId],
+    [api, userId, purpose],
   );
 
   return {

--- a/src/lib/payment/use-payment-consent.ts
+++ b/src/lib/payment/use-payment-consent.ts
@@ -1,11 +1,6 @@
 import { useCallback, useState } from 'react';
 import { useClientConfig, useCommonConfig, useSwaggerClients } from '@/adapters/external/Provider';
-import type {
-  ClientSecretRes,
-  CreateCustomerRes,
-  PaymentConsentRes,
-  VPaymentConsentListParams,
-} from '@/clients/alcohol/zinc/api';
+import type { ClientSecretRes, CreateCustomerRes, PaymentConsentRes } from '@/clients/alcohol/zinc/api';
 import { init } from '@airwallex/components-sdk';
 import { useTheme } from '@/lib/theme/provider';
 import { useHasPaymentConsent, useUserId } from '@/lib/auth/use-user';
@@ -17,12 +12,6 @@ import { useHasPaymentConsent, useUserId } from '@/lib/auth/use-user';
  *  - 'subscription' → recurring merchant-initiated (plan renewals)
  */
 export type ConsentPurpose = 'penalty' | 'subscription';
-
-// zinc's `purpose` query param on the consent endpoints ships with the
-// separate-consents work; until that deploys to pichu the generated params
-// type lacks it. The generated methods spread `...query`, so passing it is
-// runtime-safe today. Drop this cast after the next SDK regen.
-type WithPurpose<T> = T & { purpose?: ConsentPurpose };
 
 interface UsePaymentConsentOptions {
   purpose?: ConsentPurpose;
@@ -83,11 +72,7 @@ export function usePaymentConsent(options?: UsePaymentConsentOptions): UsePaymen
 
         if (purpose === 'subscription') {
           // No claim tracks the subscription consent — ask zinc directly.
-          const consentResult = await api.alcohol.zinc.api.vPaymentConsentList({
-            version: '1.0',
-            userId,
-            purpose,
-          } as WithPurpose<VPaymentConsentListParams>);
+          const consentResult = await api.alcohol.zinc.api.vPaymentConsentList({ version: '1.0', userId, purpose });
           const consentData: PaymentConsentRes = await consentResult.unwrap();
           if (consentData.hasPaymentConsent) {
             setChecking(false);
@@ -180,11 +165,7 @@ export function usePaymentConsent(options?: UsePaymentConsentOptions): UsePaymen
           attempts++;
 
           try {
-            const consentResult = await api.alcohol.zinc.api.vPaymentConsentList({
-              version: '1.0',
-              userId,
-              purpose,
-            } as WithPurpose<VPaymentConsentListParams>);
+            const consentResult = await api.alcohol.zinc.api.vPaymentConsentList({ version: '1.0', userId, purpose });
             const consentData: PaymentConsentRes = await consentResult.unwrap();
 
             if (consentData.hasPaymentConsent) {

--- a/src/pages/api/logto/[action].ts
+++ b/src/pages/api/logto/[action].ts
@@ -26,5 +26,29 @@ export default withApiLogtoOnly(buildTime, (req, res, { client: auth, baseUrl })
       return;
     }
   }
+  // Magic-link landing (app→web handoff): consume a Logto one-time token so the
+  // user arrives authenticated without a login screen. The OTT rides the OIDC
+  // authorization request as the `one_time_token` extra param; Logto's hosted
+  // experience verifies it (single-use, short expiry). An expired/used token
+  // degrades to the normal hosted sign-in page — the OIDC flow still completes
+  // and the user still lands on `redirectBackUrl`. Same-origin guard + configured
+  // baseUrl origin keep this closed to open-redirect abuse, same as sign-in above.
+  if (req.query.action === 'ott-sign-in') {
+    const ott = typeof req.query.ott === 'string' ? req.query.ott : undefined;
+    const email = typeof req.query.email === 'string' ? req.query.email : undefined;
+    const returnPath = safeReturnPath(req.query.redirectBackUrl) ?? '/billing';
+    if (!ott) {
+      res.redirect(`/api/logto/sign-in?redirectBackUrl=${encodeURIComponent(returnPath)}`);
+      return;
+    }
+    const origin = new URL(baseUrl).origin;
+    auth.handleSignIn({
+      redirectUri: `${origin}/api/logto/sign-in-callback`,
+      postRedirectUri: `${origin}${returnPath}`,
+      extraParams: { one_time_token: ott },
+      ...(email ? { loginHint: email } : {}),
+    })(req, res);
+    return;
+  }
   auth.handleAuthRoutes({ fetchUserInfo: true })(req, res);
 });

--- a/src/pages/app/payment/callback.tsx
+++ b/src/pages/app/payment/callback.tsx
@@ -6,7 +6,7 @@ import { buildTime } from '@/adapters/external/core';
 import { withServerSideAtomi } from '@/adapters/atomi/next';
 import { Card, CardContent } from '@/components/ui/card';
 import { Spinner } from '@/components/ui/spinner';
-import { usePaymentConsent } from '@/lib/payment/use-payment-consent';
+import { usePaymentConsent, type ConsentPurpose } from '@/lib/payment/use-payment-consent';
 import { useUserId } from '@/lib/auth/use-user';
 import { AlertCircle, CheckCircle2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -18,11 +18,12 @@ type PaymentCallbackStatus = 'success' | 'failed' | 'cancelled';
 interface PaymentCallbackPageProps {
   status: PaymentCallbackStatus;
   returnUrl: string | null;
+  purpose: ConsentPurpose;
 }
 
-export default function PaymentCallbackPage({ status, returnUrl }: PaymentCallbackPageProps) {
+export default function PaymentCallbackPage({ status, returnUrl, purpose }: PaymentCallbackPageProps) {
   const router = useRouter();
-  const { pollPaymentConsent } = usePaymentConsent();
+  const { pollPaymentConsent } = usePaymentConsent({ purpose });
   const userId = useUserId();
   const track = usePlausible();
   const [polling, setPolling] = useState(false);
@@ -52,9 +53,12 @@ export default function PaymentCallbackPage({ status, returnUrl }: PaymentCallba
           setPolling(false);
           setPollingComplete(true);
           // Force-refresh tokens to ensure claims updated, then redirect
-          try {
-            await fetch('/api/auth/force_tokens');
-          } catch {}
+          // (penalty consent only — no Logto claim tracks the subscription consent)
+          if (purpose !== 'subscription') {
+            try {
+              await fetch('/api/auth/force_tokens');
+            } catch {}
+          }
           // Redirect back to the return URL with all preserved query params
           if (returnUrl) {
             router.replace(returnUrl);
@@ -69,7 +73,7 @@ export default function PaymentCallbackPage({ status, returnUrl }: PaymentCallba
         },
       );
     }
-  }, [status, userId, polling, pollingComplete, pollingError, pollPaymentConsent, returnUrl, router, track]);
+  }, [status, userId, polling, pollingComplete, pollingError, pollPaymentConsent, returnUrl, router, track, purpose]);
 
   // Handle failed/cancelled payments
   if (status === 'failed' || status === 'cancelled') {
@@ -147,9 +151,11 @@ export default function PaymentCallbackPage({ status, returnUrl }: PaymentCallba
                         track(TrackingEvents.Payment.Callback.PollingSuccess);
                         setPolling(false);
                         setPollingComplete(true);
-                        try {
-                          await fetch('/api/auth/force_tokens');
-                        } catch {}
+                        if (purpose !== 'subscription') {
+                          try {
+                            await fetch('/api/auth/force_tokens');
+                          } catch {}
+                        }
                         router.replace(returnUrl || '/app');
                       },
                       () => {
@@ -249,6 +255,7 @@ export const getServerSideProps = withServerSideAtomi(
       payment_status,
       status: statusParam,
       return_url,
+      purpose: purposeParam,
     } = context.query as Record<string, string | string[] | undefined>;
 
     // Normalize possibly-array query params to a lowercase string
@@ -282,10 +289,15 @@ export const getServerSideProps = withServerSideAtomi(
     // Decode return URL if present
     const returnUrl = typeof return_url === 'string' ? decodeURIComponent(return_url) : null;
 
+    // Which consent this callback confirms; anything but 'subscription' is the
+    // original penalty flow.
+    const purpose: ConsentPurpose = normalize(purposeParam) === 'subscription' ? 'subscription' : 'penalty';
+
     return {
       props: {
         status,
         returnUrl,
+        purpose,
       },
     };
   },

--- a/src/pages/billing/checkout.tsx
+++ b/src/pages/billing/checkout.tsx
@@ -1,0 +1,297 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { GetServerSidePropsResult } from 'next';
+import Head from 'next/head';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { buildTime } from '@/adapters/external/core';
+import { withServerSideAtomi } from '@/adapters/atomi/next';
+import { useProblemReporter } from '@/adapters/problem-reporter/providers/hooks';
+import type { SubscriptionRes } from '@/clients/alcohol/zinc/api';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { AsyncButton } from '@/components/ui/async-button';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Spinner } from '@/components/ui/spinner';
+import { chargeFailureIntentStatus, classifyBillingError, type BillingErrorKind } from '@/lib/billing/errors';
+import { TIER_PRICING, formatUsdCents, parsePaidTier, type PaidTier } from '@/lib/billing/pricing';
+import { useSubscription } from '@/lib/billing/use-subscription';
+import type { Problem } from '@/lib/problem/core';
+import { usePaymentConsent } from '@/lib/payment/use-payment-consent';
+import { AlertCircle, CheckCircle2, CreditCard, ShieldCheck } from 'lucide-react';
+
+interface CheckoutPageProps {
+  tier: PaidTier;
+  /** Present after the Airwallex HPP round-trip — auto-continue with subscribe. */
+  resume: boolean;
+}
+
+type CheckoutPhase = 'idle' | 'subscribing' | 'success';
+
+interface CheckoutError {
+  kind: BillingErrorKind;
+  message: string;
+}
+
+export default function CheckoutPage({ tier, resume }: CheckoutPageProps) {
+  const router = useRouter();
+  const problemReporter = useProblemReporter();
+  const { subscribe } = useSubscription();
+  const { checkAndInitiatePayment, checking } = usePaymentConsent({ purpose: 'subscription' });
+
+  const [phase, setPhase] = useState<CheckoutPhase>('idle');
+  const [error, setError] = useState<CheckoutError | null>(null);
+  const [result, setResult] = useState<SubscriptionRes | null>(null);
+  const resumedRef = useRef(false);
+  const retriedRef = useRef(false);
+
+  const pricing = TIER_PRICING[tier];
+  const resumeUrl = useMemo(() => `/billing/checkout?tier=${tier}&resume=1`, [tier]);
+
+  const describeProblem = useCallback((problem: Problem): CheckoutError => {
+    const kind = classifyBillingError(problem);
+    switch (kind) {
+      case 'no_payment_consent':
+        return { kind, message: 'Set up a payment method first — it only takes a minute.' };
+      case 'subscription_charge_failed': {
+        const intentStatus = chargeFailureIntentStatus(problem);
+        return {
+          kind,
+          message: `Your card was declined${intentStatus ? ` (${intentStatus})` : ''}. Check with your bank, try again, or use a different card.`,
+        };
+      }
+      case 'renewal_in_progress':
+        return { kind, message: "We're processing your account — this usually resolves in a moment." };
+      default:
+        return { kind, message: problem.detail || 'Something went wrong. Please try again.' };
+    }
+  }, []);
+
+  const runSubscribe = useCallback(async () => {
+    setPhase('subscribing');
+    setError(null);
+    const res = await subscribe(tier);
+    await res.match({
+      ok: async data => {
+        setResult(data);
+        setPhase('success');
+      },
+      err: async problem => {
+        const kind = classifyBillingError(problem);
+        if (kind === 'already_subscribed') {
+          // Someone's ahead of us — the billing page is the source of truth.
+          await router.replace('/billing');
+          return;
+        }
+        problemReporter.pushError(new Error(problem.title || 'Subscribe failed'), {
+          source: 'billing/checkout-subscribe',
+          problem,
+        });
+        if (kind === 'renewal_in_progress' && !retriedRef.current) {
+          retriedRef.current = true;
+          setError(describeProblem(problem));
+          await new Promise(r => setTimeout(r, 5000));
+          await runSubscribe();
+          return;
+        }
+        setError(describeProblem(problem));
+        setPhase('idle');
+      },
+    });
+  }, [subscribe, tier, router, problemReporter, describeProblem]);
+
+  const startCheckout = useCallback(() => {
+    setError(null);
+    // If the subscription consent already exists this fires immediately;
+    // otherwise the browser redirects to the Airwallex HPP and returns to
+    // this page with resume=1 via the payment callback.
+    checkAndInitiatePayment(() => {
+      void runSubscribe();
+    }, resumeUrl).catch(() => {
+      setError({ kind: 'unknown', message: 'Could not start payment setup. Please try again.' });
+    });
+  }, [checkAndInitiatePayment, resumeUrl, runSubscribe]);
+
+  // Returning from the HPP round-trip: continue with the subscribe call once.
+  useEffect(() => {
+    if (resume && !resumedRef.current) {
+      resumedRef.current = true;
+      void runSubscribe();
+    }
+  }, [resume, runSubscribe]);
+
+  const busy = checking || phase === 'subscribing';
+
+  return (
+    <>
+      <Head>
+        <title>Checkout - LazyTax</title>
+        <meta name="robots" content="noindex" />
+      </Head>
+
+      <div className="container mx-auto px-4 py-8 max-w-xl">
+        <div className="mb-6">
+          <h1 className="text-3xl font-bold text-slate-900 dark:text-slate-100 flex items-center gap-3">
+            <CreditCard className="w-8 h-8" />
+            Checkout
+          </h1>
+        </div>
+
+        {phase === 'success' && result ? (
+          <Card>
+            <CardContent className="space-y-6 p-8 text-center">
+              <div className="flex justify-center">
+                <div className="rounded-full bg-green-100 dark:bg-green-900/20 p-4">
+                  <CheckCircle2 className="h-12 w-12 text-green-600 dark:text-green-400" />
+                </div>
+              </div>
+              <div className="space-y-2">
+                <h2 className="text-2xl font-semibold">You're on {pricing.label}!</h2>
+                <p className="text-slate-600 dark:text-slate-400">
+                  Your plan renews on{' '}
+                  {result.periodEnd
+                    ? new Date(result.periodEnd).toLocaleDateString(undefined, {
+                        year: 'numeric',
+                        month: 'long',
+                        day: 'numeric',
+                      })
+                    : 'your next billing date'}
+                  .
+                </p>
+              </div>
+              <Button asChild className="w-full">
+                <Link href="/billing">Manage subscription</Link>
+              </Button>
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="space-y-4">
+            {error && (
+              <Alert variant="destructive">
+                <AlertCircle className="h-4 w-4" />
+                <AlertTitle>
+                  {error.kind === 'subscription_charge_failed' ? 'Payment declined' : 'Something needs your attention'}
+                </AlertTitle>
+                <AlertDescription className="space-y-3">
+                  <p>{error.message}</p>
+                  <div className="flex flex-wrap gap-2">
+                    {error.kind === 'subscription_charge_failed' && (
+                      <>
+                        <Button size="sm" variant="outline" onClick={() => void runSubscribe()} disabled={busy}>
+                          Try again
+                        </Button>
+                        <Button size="sm" variant="outline" onClick={startCheckout} disabled={busy}>
+                          Use a different card
+                        </Button>
+                      </>
+                    )}
+                    {error.kind === 'no_payment_consent' && (
+                      <Button size="sm" variant="outline" onClick={startCheckout} disabled={busy}>
+                        Set up payment method
+                      </Button>
+                    )}
+                    {error.kind === 'renewal_in_progress' && (
+                      <Button size="sm" variant="outline" onClick={() => void runSubscribe()} disabled={busy}>
+                        Try again
+                      </Button>
+                    )}
+                  </div>
+                </AlertDescription>
+              </Alert>
+            )}
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  {pricing.label} plan
+                  <Badge variant="secondary">Launch price</Badge>
+                </CardTitle>
+                <CardDescription>
+                  <span className="line-through mr-1">{formatUsdCents(pricing.originalCents)}</span>
+                  <span className="font-semibold text-slate-900 dark:text-slate-100">
+                    {formatUsdCents(pricing.launchCents)}/month
+                  </span>{' '}
+                  · billed monthly · cancel anytime
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {phase === 'subscribing' ? (
+                  <div className="flex items-center gap-3 text-slate-600 dark:text-slate-400">
+                    <Spinner size="sm" variant="rays" />
+                    <span>Activating your plan…</span>
+                  </div>
+                ) : (
+                  <AsyncButton className="w-full" loading={checking} onClick={startCheckout}>
+                    {checking
+                      ? 'Preparing secure payment…'
+                      : `Subscribe for ${formatUsdCents(pricing.launchCents)}/month`}
+                  </AsyncButton>
+                )}
+                <p className="text-xs text-slate-500 dark:text-slate-500 flex items-center gap-1.5">
+                  <ShieldCheck className="w-3.5 h-3.5" />
+                  Card details are handled by Airwallex — they never touch our servers.
+                </p>
+              </CardContent>
+            </Card>
+
+            <p className="text-sm text-slate-500 dark:text-slate-500">
+              Want a different plan?{' '}
+              <Link className="underline" href={`/billing/checkout?tier=${tier === 'pro' ? 'ultimate' : 'pro'}`}>
+                See {tier === 'pro' ? 'Ultimate' : 'Pro'}
+              </Link>{' '}
+              or go back to{' '}
+              <Link className="underline" href="/billing">
+                billing
+              </Link>
+              .
+            </p>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}
+
+export const getServerSideProps = withServerSideAtomi(
+  // guard:'public' + explicit auth check so signed-out visitors (e.g. from the
+  // marketing pricing page) round-trip through login and land back here with
+  // the tier preserved.
+  { ...buildTime, guard: 'public' },
+  async (context, { apiTree, auth }): Promise<GetServerSidePropsResult<CheckoutPageProps>> => {
+    const tier = parsePaidTier(Array.isArray(context.query.tier) ? context.query.tier[0] : context.query.tier);
+    if (!tier) {
+      return { redirect: { destination: '/billing', permanent: false } };
+    }
+
+    const userId = await auth.retriever
+      .getClaims()
+      .map((x): string | null => (x.value.isAuthed ? x.value.data.sub : null))
+      .unwrapOr(null);
+    if (!userId) {
+      return {
+        redirect: {
+          destination: `/api/logto/sign-in?redirectBackUrl=${encodeURIComponent(
+            context.resolvedUrl || `/billing/checkout?tier=${tier}`,
+          )}`,
+          permanent: false,
+        },
+      };
+    }
+
+    // Already on this tier (and not pending cancellation)? Nothing to buy.
+    const currentResult = await apiTree.alcohol.zinc.api.vSubscriptionDetail({ version: '1.0', userId });
+    const current = await currentResult.map((x): SubscriptionRes | null => x).unwrapOr(null);
+    if (
+      current &&
+      current.tier === tier &&
+      (current.status === 'active' || current.status === 'grace') &&
+      !current.cancelAtPeriodEnd
+    ) {
+      return { redirect: { destination: '/billing', permanent: false } };
+    }
+
+    const resume = (Array.isArray(context.query.resume) ? context.query.resume[0] : context.query.resume) === '1';
+
+    return { props: { tier, resume } };
+  },
+);

--- a/src/pages/billing/index.tsx
+++ b/src/pages/billing/index.tsx
@@ -75,11 +75,15 @@ export default function BillingPage({ initial }: BillingPageProps) {
         await router.replace(router.asPath);
       },
       err: async problem => {
-        problemReporter.pushError(new Error(problem.title || 'Billing action failed'), {
-          source: `billing/${source}`,
-          problem,
-        });
         const kind = classifyBillingError(problem);
+        // already_subscribed / no_active_subscription are benign state drift
+        // resolved by a refresh — not errors worth reporting.
+        if (kind !== 'already_subscribed' && kind !== 'no_active_subscription') {
+          problemReporter.pushError(new Error(problem.title || 'Billing action failed'), {
+            source: `billing/${source}`,
+            problem,
+          });
+        }
         switch (kind) {
           case 'no_payment_consent': {
             setBanner('Set up a payment method to continue.');

--- a/src/pages/billing/index.tsx
+++ b/src/pages/billing/index.tsx
@@ -1,0 +1,373 @@
+import { useMemo, useRef, useState } from 'react';
+import type { GetServerSidePropsResult } from 'next';
+import Head from 'next/head';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { buildTime } from '@/adapters/external/core';
+import { withServerSideAtomi } from '@/adapters/atomi/next';
+import { useProblemReporter } from '@/adapters/problem-reporter/providers/hooks';
+import type { SubscriptionRes } from '@/clients/alcohol/zinc/api';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { AsyncButton } from '@/components/ui/async-button';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { Spinner } from '@/components/ui/spinner';
+import { chargeFailureIntentStatus, classifyBillingError } from '@/lib/billing/errors';
+import {
+  TIER_PRICING,
+  TIER_RANK,
+  formatUsdCents,
+  parsePaidTier,
+  tierLabel,
+  type PaidTier,
+} from '@/lib/billing/pricing';
+import { useSubscription } from '@/lib/billing/use-subscription';
+import { useContent } from '@/lib/content/providers';
+import { useFreeLoader } from '@/lib/content/providers/useFreeLoader';
+import type { Result, ResultSerial } from '@/lib/monads/result';
+import { Res } from '@/lib/monads/result';
+import type { Problem } from '@/lib/problem/core';
+import { usePaymentConsent } from '@/lib/payment/use-payment-consent';
+import { AlertCircle, ArrowDownCircle, ArrowUpCircle, CreditCard, RotateCcw, XCircle } from 'lucide-react';
+
+type BillingPageProps = { initial: ResultSerial<SubscriptionRes, Problem> };
+
+type PendingAction = 'cancel' | 'resume' | 'upgrade' | 'downgrade' | null;
+
+function formatDate(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '—';
+  return d.toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' });
+}
+
+export default function BillingPage({ initial }: BillingPageProps) {
+  const router = useRouter();
+  const problemReporter = useProblemReporter();
+  const { cancel, changeTier, unCancel } = useSubscription();
+  const { checkAndInitiatePayment, checking } = usePaymentConsent({ purpose: 'subscription' });
+
+  const dataResult = useMemo(() => Res.fromSerial<SubscriptionRes, Problem>(initial), [initial]);
+  const [, loader] = useFreeLoader();
+  const sub = useContent(dataResult, { loader, notFound: 'Subscription data not found' });
+
+  const [confirm, setConfirm] = useState<PendingAction>(null);
+  const [acting, setActing] = useState(false);
+  const [banner, setBanner] = useState<string | null>(null);
+  const retriedRef = useRef(false);
+
+  if (!sub) return null; // useContent handles loading/error states
+
+  const paidTier = parsePaidTier(sub.tier);
+  const isPaid = paidTier != null && (sub.status === 'active' || sub.status === 'grace');
+  const otherTier: PaidTier | null = paidTier === 'pro' ? 'ultimate' : paidTier === 'ultimate' ? 'pro' : null;
+  const otherIsUpgrade = paidTier != null && otherTier != null && TIER_RANK[otherTier] > TIER_RANK[paidTier];
+
+  const runAction = async (action: () => Promise<Result<SubscriptionRes, Problem>>, source: string) => {
+    setActing(true);
+    setBanner(null);
+    const result = await action();
+    await result.match({
+      ok: async () => {
+        retriedRef.current = false;
+        await router.replace(router.asPath);
+      },
+      err: async problem => {
+        problemReporter.pushError(new Error(problem.title || 'Billing action failed'), {
+          source: `billing/${source}`,
+          problem,
+        });
+        const kind = classifyBillingError(problem);
+        switch (kind) {
+          case 'no_payment_consent': {
+            setBanner('Set up a payment method to continue.');
+            break;
+          }
+          case 'subscription_charge_failed': {
+            const intentStatus = chargeFailureIntentStatus(problem);
+            setBanner(
+              `Your card was declined${intentStatus ? ` (${intentStatus})` : ''}. Check with your bank or update your payment method, then try again.`,
+            );
+            break;
+          }
+          case 'renewal_in_progress': {
+            if (!retriedRef.current) {
+              retriedRef.current = true;
+              setBanner("We're processing your renewal — retrying in a moment…");
+              await new Promise(res => setTimeout(res, 5000));
+              await runAction(action, source);
+              return;
+            }
+            setBanner("We're processing your renewal — please try again in a moment.");
+            break;
+          }
+          case 'already_subscribed':
+          case 'no_active_subscription': {
+            // State is out of date — refresh from the server.
+            await router.replace(router.asPath);
+            break;
+          }
+          default:
+            setBanner(problem.detail || 'Something went wrong. Please try again.');
+        }
+      },
+    });
+    setActing(false);
+    setConfirm(null);
+  };
+
+  const startConsentUpdate = () => {
+    checkAndInitiatePayment(() => router.replace(router.asPath), '/billing').catch(() => {
+      setBanner('Could not start payment setup. Please try again.');
+    });
+  };
+
+  return (
+    <>
+      <Head>
+        <title>Billing - LazyTax</title>
+        <meta name="robots" content="noindex" />
+      </Head>
+
+      <div className="container mx-auto px-4 py-8 max-w-3xl">
+        <div className="mb-6">
+          <h1 className="text-3xl font-bold text-slate-900 dark:text-slate-100 flex items-center gap-3">
+            <CreditCard className="w-8 h-8" />
+            Billing
+          </h1>
+          <p className="text-slate-600 dark:text-slate-400 mt-2">Manage your subscription</p>
+        </div>
+
+        {banner && (
+          <Alert variant="destructive" className="mb-4">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Something needs your attention</AlertTitle>
+            <AlertDescription>{banner}</AlertDescription>
+          </Alert>
+        )}
+
+        {!isPaid && (
+          <div className="space-y-4">
+            <Card>
+              <CardHeader>
+                <CardTitle>You're on Free</CardTitle>
+                <CardDescription>Upgrade to unlock more habits, skips, freezes and vacation windows.</CardDescription>
+              </CardHeader>
+            </Card>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              {(['pro', 'ultimate'] as const).map(tier => (
+                <Card key={tier}>
+                  <CardHeader>
+                    <CardTitle className="flex items-center gap-2">
+                      {TIER_PRICING[tier].label}
+                      <Badge variant="secondary">Launch price</Badge>
+                    </CardTitle>
+                    <CardDescription>
+                      <span className="line-through mr-1">{formatUsdCents(TIER_PRICING[tier].originalCents)}</span>
+                      <span className="font-semibold text-slate-900 dark:text-slate-100">
+                        {formatUsdCents(TIER_PRICING[tier].launchCents)}/month
+                      </span>
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <Button asChild className="w-full">
+                      <Link href={`/billing/checkout?tier=${tier}`}>Get {TIER_PRICING[tier].label}</Link>
+                    </Button>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {isPaid && paidTier && (
+          <div className="space-y-4">
+            {sub.status === 'grace' && (
+              <Alert variant="destructive">
+                <AlertCircle className="h-4 w-4" />
+                <AlertTitle>Payment problem</AlertTitle>
+                <AlertDescription className="space-y-2">
+                  <p>
+                    We couldn't charge your card, and we'll retry soon. Update your payment method to keep your plan.
+                  </p>
+                  <Button size="sm" variant="outline" onClick={startConsentUpdate} disabled={checking}>
+                    {checking ? (
+                      <>
+                        Starting… <Spinner size="sm" variant="rays" />
+                      </>
+                    ) : (
+                      'Update payment method'
+                    )}
+                  </Button>
+                </AlertDescription>
+              </Alert>
+            )}
+
+            {sub.cancelAtPeriodEnd && (
+              <Alert>
+                <AlertCircle className="h-4 w-4" />
+                <AlertTitle>Your plan ends on {formatDate(sub.periodEnd)}</AlertTitle>
+                <AlertDescription>
+                  You'll keep {TIER_PRICING[paidTier].label} until then, with no further charges. Changed your mind? You
+                  can resume below.
+                </AlertDescription>
+              </Alert>
+            )}
+
+            {!sub.cancelAtPeriodEnd && sub.nextTier && sub.nextTier !== sub.tier && (
+              <Alert>
+                <AlertCircle className="h-4 w-4" />
+                <AlertTitle>Plan change scheduled</AlertTitle>
+                <AlertDescription>
+                  Your plan changes to {tierLabel(sub.nextTier)} on {formatDate(sub.periodEnd)}.
+                </AlertDescription>
+              </Alert>
+            )}
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  Current plan: {TIER_PRICING[paidTier].label}
+                  <Badge variant={sub.status === 'grace' ? 'destructive' : 'default'}>
+                    {sub.status === 'grace' ? 'Payment issue' : 'Active'}
+                  </Badge>
+                </CardTitle>
+                <CardDescription>
+                  {formatUsdCents(TIER_PRICING[paidTier].launchCents)}/month
+                  {!sub.cancelAtPeriodEnd && <> · Renews on {formatDate(sub.periodEnd)}</>}
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="flex flex-col sm:flex-row gap-3">
+                {sub.cancelAtPeriodEnd ? (
+                  <AsyncButton
+                    loading={acting && confirm === 'resume'}
+                    onClick={() => setConfirm('resume')}
+                    idleIcon={<RotateCcw className="w-4 h-4" />}
+                  >
+                    Resume subscription
+                  </AsyncButton>
+                ) : (
+                  <>
+                    {otherTier && (
+                      <AsyncButton
+                        loading={acting && confirm === (otherIsUpgrade ? 'upgrade' : 'downgrade')}
+                        onClick={() => setConfirm(otherIsUpgrade ? 'upgrade' : 'downgrade')}
+                        idleIcon={
+                          otherIsUpgrade ? (
+                            <ArrowUpCircle className="w-4 h-4" />
+                          ) : (
+                            <ArrowDownCircle className="w-4 h-4" />
+                          )
+                        }
+                      >
+                        {otherIsUpgrade
+                          ? `Upgrade to ${TIER_PRICING[otherTier].label}`
+                          : `Switch to ${TIER_PRICING[otherTier].label}`}
+                      </AsyncButton>
+                    )}
+                    <Button variant="destructive" onClick={() => setConfirm('cancel')} disabled={acting}>
+                      <XCircle className="w-4 h-4" /> Cancel subscription
+                    </Button>
+                  </>
+                )}
+              </CardContent>
+            </Card>
+
+            <ConfirmDialog
+              open={confirm === 'cancel'}
+              onOpenChange={open => !open && setConfirm(null)}
+              onCancel={() => setConfirm(null)}
+              onConfirm={() => runAction(() => cancel(), 'cancel')}
+              loading={acting}
+              title="Cancel subscription?"
+              confirmLabel="Cancel subscription"
+              cancelLabel="Keep my plan"
+              description={
+                <span>
+                  You'll keep {TIER_PRICING[paidTier].label} until {formatDate(sub.periodEnd)}, then move to Free. No
+                  further charges.
+                </span>
+              }
+            />
+
+            <ConfirmDialog
+              open={confirm === 'resume'}
+              onOpenChange={open => !open && setConfirm(null)}
+              onCancel={() => setConfirm(null)}
+              onConfirm={() => runAction(() => unCancel(paidTier), 'resume')}
+              loading={acting}
+              confirmVariant="default"
+              title="Resume subscription?"
+              confirmLabel="Resume"
+              cancelLabel="Never mind"
+              description={
+                <span>
+                  Your {TIER_PRICING[paidTier].label} plan will continue and renew on {formatDate(sub.periodEnd)}. You
+                  won't be charged now.
+                </span>
+              }
+            />
+
+            {otherTier && (
+              <ConfirmDialog
+                open={confirm === 'upgrade' || confirm === 'downgrade'}
+                onOpenChange={open => !open && setConfirm(null)}
+                onCancel={() => setConfirm(null)}
+                onConfirm={() => runAction(() => changeTier(otherTier), otherIsUpgrade ? 'upgrade' : 'downgrade')}
+                loading={acting}
+                confirmVariant="default"
+                title={
+                  otherIsUpgrade
+                    ? `Upgrade to ${TIER_PRICING[otherTier].label}?`
+                    : `Switch to ${TIER_PRICING[otherTier].label}?`
+                }
+                confirmLabel={otherIsUpgrade ? 'Upgrade now' : 'Schedule switch'}
+                cancelLabel="Never mind"
+                description={
+                  otherIsUpgrade ? (
+                    <span>
+                      You'll be charged {formatUsdCents(TIER_PRICING[otherTier].launchCents)} now and your billing
+                      period restarts today.
+                    </span>
+                  ) : (
+                    <span>
+                      You'll keep {TIER_PRICING[paidTier].label} until {formatDate(sub.periodEnd)}, then switch to{' '}
+                      {TIER_PRICING[otherTier].label} at {formatUsdCents(TIER_PRICING[otherTier].launchCents)}/month.
+                    </span>
+                  )
+                }
+              />
+            )}
+          </div>
+        )}
+      </div>
+    </>
+  );
+}
+
+export const getServerSideProps = withServerSideAtomi(
+  // guard:'public' + explicit auth check so signed-out visitors get a login
+  // round-trip back here instead of the global error page.
+  { ...buildTime, guard: 'public' },
+  async (context, { apiTree, auth }): Promise<GetServerSidePropsResult<BillingPageProps>> => {
+    const userId = await auth.retriever
+      .getClaims()
+      .map((x): string | null => (x.value.isAuthed ? x.value.data.sub : null))
+      .unwrapOr(null);
+    if (!userId) {
+      return {
+        redirect: {
+          destination: `/api/logto/sign-in?redirectBackUrl=${encodeURIComponent(context.resolvedUrl || '/billing')}`,
+          permanent: false,
+        },
+      };
+    }
+
+    const result = await apiTree.alcohol.zinc.api.vSubscriptionDetail({ version: '1.0', userId });
+    const initial: ResultSerial<SubscriptionRes, Problem> = await result.serial();
+    return { props: { initial } };
+  },
+);

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import type { GetServerSidePropsResult } from 'next';
 import Head from 'next/head';
+import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { buildTime } from '@/adapters/external/core';
 import { withServerSideAtomi } from '@/adapters/atomi/next';
@@ -209,6 +210,17 @@ export default function SettingsPage({ initial }: SettingsPageProps) {
               />
             </FieldCard>
           )}
+
+          <FieldCard
+            label="Subscription"
+            subtitle="View your plan, renewal date and billing options"
+            restriction="Cancel or change tier anytime"
+            contentClassName="space-y-2"
+          >
+            <Button asChild variant="outline" className="inline-flex items-center gap-2 px-3 py-2">
+              <Link href="/billing">Manage subscription</Link>
+            </Button>
+          </FieldCard>
 
           {!hasPaymentConsent && (
             <FieldCard


### PR DESCRIPTION
Implements the argon side of the billing portal (ClickUp 86ey5m5bp).

## What

- **`/billing`** — subscription management: current tier + renewal date, cancel-at-period-end, resume (re-subscribe same tier), upgrade (immediate, period resets) / downgrade (at period end, `nextTier`), grace-state "update payment method" recovery
- **`/billing/checkout?tier=pro|ultimate`** — monthly checkout at launch prices ($4.99/$7.99, struck $9.99/$14.99); Airwallex HPP consent flow (recurring MIT), auto-resumes the subscribe call after the redirect round-trip
- **`/api/logto/ott-sign-in`** — magic-link landing for app→web handoff: consumes a Logto one-time token via `extraParams`, same-origin `redirectBackUrl` guard, expired/used tokens degrade to the normal hosted login
- **Purpose-aware consent hook** — `usePaymentConsent({ purpose: 'subscription' })` uses `merchant_trigger_reason: 'recurring'` and polls `GET /consent?purpose=subscription`; never consults the penalty-only `has_payment_consent` Logto claim. Penalty flow (stakes/donations) unchanged
- **Marketing `/pricing`** — Coming Soon overlays removed, per-card CTAs link to checkout with tier preselected (login round-trip preserves the tier)
- zinc SDK regenerated (subscription endpoints + purpose-scoped consent params, live on pichu)

## Error surface

`no_payment_consent` (412) → consent setup CTA · `subscription_charge_failed` (402) → decline message with intentStatus + retry/different-card · `renewal_in_progress` (409) → one auto-retry then manual · `already_subscribed` → redirect to /billing

## Verified

- type-check, pre-commit lint, OpenNext build all green
- dev-server smoke tests: unauthed `/billing` + checkout → login round-trip with return URL; invalid tier → redirect; OTT fallback + open-redirect guard verified (evil `redirectBackUrl` rejected, `one_time_token` rides the OIDC request)
- End-to-end card flow on pichu pending manual run (needs Airwallex demo card)

Related: AtomiCloud/alcohol.zinc#65 (launch price alignment), Konnect catalog mirror updated to $4.99/$7.99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013TsgJ4AZ8U3vQniHR8wGtu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a billing flow with subscription checkout, plan management, and subscription status pages.
  * Added direct checkout links for Pro and Ultimate plans.
  * Added a billing section in Settings for quick access to subscription management.
  * Added support for magic-link sign-in during billing entry.

* **Bug Fixes**
  * Improved payment consent handling for subscription vs. penalty flows.
  * Added clearer billing error handling and retry behavior for subscription-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->