### PR TITLE
feat: /auth/handoff landing matching zinc web-handoff link contract

### DIFF
--- a/src/pages/auth/handoff.tsx
+++ b/src/pages/auth/handoff.tsx
@@ -1,0 +1,32 @@
+import type { GetServerSideProps } from 'next';
+
+// Magic-link landing for the neon→web handoff. zinc's web-handoff endpoint
+// (alcohol.zinc WebHandoffService.BuildUrl) mints links of the shape
+//   /auth/handoff?one_time_token=...&login_hint=...&redirect=/billing
+// with param names deliberately matching Logto's signIn extraParams keys.
+// This page just forwards them to the Logto OTT sign-in API route, which
+// applies the same-origin guard on the redirect path.
+const first = (v: string | string[] | undefined): string | undefined => (Array.isArray(v) ? v[0] : v);
+
+export const getServerSideProps: GetServerSideProps = async context => {
+  const ott = first(context.query.one_time_token);
+  const email = first(context.query.login_hint);
+  const redirect = first(context.query.redirect) ?? '/billing';
+
+  const params = new URLSearchParams();
+  if (ott) params.set('ott', ott);
+  if (email) params.set('email', email);
+  params.set('redirectBackUrl', redirect);
+
+  return {
+    redirect: {
+      destination: `/api/logto/ott-sign-in?${params.toString()}`,
+      permanent: false,
+    },
+  };
+};
+
+// Never rendered — gssp always redirects.
+export default function AuthHandoffPage() {
+  return null;
+}


### PR DESCRIPTION
zinc's `POST /api/v1/Auth/web-handoff` (live on pichu, v1.27.0) mints magic links of the shape:

```
https://argon-alcohol-pichu…/auth/handoff?one_time_token=…&login_hint=…&redirect=/billing
```

(`WebPortal` config in alcohol.zinc; param names deliberately match Logto's `signIn` extraParams keys.)

This adds the `/auth/handoff` landing page: a gssp-only redirect that maps those params onto the existing `/api/logto/ott-sign-in` route from #94, which applies the same-origin guard on the redirect path and degrades expired/used tokens to normal login.

Completes the argon side of the neon→web handoff contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013TsgJ4AZ8U3vQniHR8wGtu