### PR TITLE
fix: treat subscription consent pre-check errors as no-consent

### DIFF
--- a/src/lib/payment/use-payment-consent.ts
+++ b/src/lib/payment/use-payment-consent.ts
@@ -71,10 +71,15 @@ export function usePaymentConsent(options?: UsePaymentConsentOptions): UsePaymen
         }
 
         if (purpose === 'subscription') {
-          // No claim tracks the subscription consent — ask zinc directly.
+          // No claim tracks the subscription consent — ask zinc directly. A
+          // fresh user has no payment customer yet, so an error here (404
+          // included) just means "no consent" and we proceed to setup.
           const consentResult = await api.alcohol.zinc.api.vPaymentConsentList({ version: '1.0', userId, purpose });
-          const consentData: PaymentConsentRes = await consentResult.unwrap();
-          if (consentData.hasPaymentConsent) {
+          const hasSubscriptionConsent = await consentResult.match({
+            ok: (data: PaymentConsentRes) => data.hasPaymentConsent === true,
+            err: () => false,
+          });
+          if (hasSubscriptionConsent) {
             setChecking(false);
             onSuccess();
             return;


### PR DESCRIPTION
Found live on pichu during the e2e run: a brand-new user (no payment customer record) gets a 404 from `GET /Payment/{userId}/consent?purpose=subscription`, and the checkout's consent pre-check `unwrap()`ed it — aborting with "Could not start payment setup" before the Airwallex flow could start.

The penalty flow never hits this because it creates the customer before ever querying consent. Fix: `match` the pre-check Result and treat any error as "no consent yet", proceeding into setup (which creates the customer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013TsgJ4AZ8U3vQniHR8wGtu