### PR TITLE
feat: NFC tag landing + AASA/assetlinks for /t/*

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,0 +1,20 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appIDs": [
+          "MNPSXJP9PN.cloud.atomi.alcohol.neon.pichu",
+          "MNPSXJP9PN.cloud.atomi.alcohol.neon.pikachu",
+          "MNPSXJP9PN.cloud.atomi.alcohol.neon.raichu"
+        ],
+        "components": [
+          {
+            "/": "/t/*",
+            "comment": "NFC habit tags: open the neon app to resolve and complete the linked habit"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -4,9 +4,9 @@
     "details": [
       {
         "appIDs": [
-          "MNPSXJP9PN.cloud.atomi.alcohol.neon.pichu",
-          "MNPSXJP9PN.cloud.atomi.alcohol.neon.pikachu",
-          "MNPSXJP9PN.cloud.atomi.alcohol.neon.raichu"
+          "MNPSXJP9PN.cloud.atomi.pichu.alcohol.neon.app",
+          "MNPSXJP9PN.cloud.atomi.pikachu.alcohol.neon.app",
+          "MNPSXJP9PN.cloud.atomi.raichu.alcohol.neon.app"
         ],
         "components": [
           {

--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -1,0 +1,26 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "cloud.atomi.alcohol_neon.pichu",
+      "sha256_cert_fingerprints": ["REPLACE_WITH_PLAY_APP_SIGNING_SHA256"]
+    }
+  },
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "cloud.atomi.alcohol_neon.pikachu",
+      "sha256_cert_fingerprints": ["REPLACE_WITH_PLAY_APP_SIGNING_SHA256"]
+    }
+  },
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "cloud.atomi.alcohol_neon.raichu",
+      "sha256_cert_fingerprints": ["REPLACE_WITH_PLAY_APP_SIGNING_SHA256"]
+    }
+  }
+]

--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -3,7 +3,7 @@
     "relation": ["delegate_permission/common.handle_all_urls"],
     "target": {
       "namespace": "android_app",
-      "package_name": "cloud.atomi.alcohol_neon.pichu",
+      "package_name": "cloud.atomi.pichu.alcohol.neon.app",
       "sha256_cert_fingerprints": ["REPLACE_WITH_PLAY_APP_SIGNING_SHA256"]
     }
   },
@@ -11,7 +11,7 @@
     "relation": ["delegate_permission/common.handle_all_urls"],
     "target": {
       "namespace": "android_app",
-      "package_name": "cloud.atomi.alcohol_neon.pikachu",
+      "package_name": "cloud.atomi.pikachu.alcohol.neon.app",
       "sha256_cert_fingerprints": ["REPLACE_WITH_PLAY_APP_SIGNING_SHA256"]
     }
   },
@@ -19,7 +19,7 @@
     "relation": ["delegate_permission/common.handle_all_urls"],
     "target": {
       "namespace": "android_app",
-      "package_name": "cloud.atomi.alcohol_neon.raichu",
+      "package_name": "cloud.atomi.raichu.alcohol.neon.app",
       "sha256_cert_fingerprints": ["REPLACE_WITH_PLAY_APP_SIGNING_SHA256"]
     }
   }

--- a/public/_headers
+++ b/public/_headers
@@ -17,4 +17,14 @@
   Cache-Control: public,max-age=86400
 
 /*.webp
-  Cache-Control: public,max-age=86400 
+  Cache-Control: public,max-age=86400
+
+# Universal/App Links verification files. Apple requires application/json
+# (the file has no extension so it would default to octet-stream); short cache
+# so entitlement changes propagate quickly.
+/.well-known/apple-app-site-association
+  Content-Type: application/json
+  Cache-Control: public,max-age=3600
+
+/.well-known/assetlinks.json
+  Cache-Control: public,max-age=3600 

--- a/src/pages/t/[id].tsx
+++ b/src/pages/t/[id].tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Nfc } from 'lucide-react';
-import { useCommonConfig } from '@/adapters/external/Provider';
+import { useConfig } from '@/adapters/external/Provider';
 
 // Fallback landing for NFC habit tags (lazytax.club/t/{tagId}). Owners with the
 // app never see this page — the OS intercepts /t/* via Universal/App Links and
@@ -13,7 +13,7 @@ import { useCommonConfig } from '@/adapters/external/Provider';
 // resolves nothing and shows no habit data (tag ids mean nothing without the
 // owner's auth).
 export default function NfcTagLandingPage() {
-  const common = useCommonConfig();
+  const { common } = useConfig();
   const appName = common.app.name;
 
   return (
@@ -26,7 +26,8 @@ export default function NfcTagLandingPage() {
         />
         <meta name="robots" content="noindex" />
       </Head>
-      <main className="flex min-h-screen items-center justify-center px-4 py-12">
+      {/* Layout already renders the page-level <main>; keep this a plain section. */}
+      <section className="flex min-h-[60vh] items-center justify-center px-4 py-12">
         <Card className="w-full max-w-md text-center">
           <CardHeader className="items-center">
             <Image src="/mascot.svg" alt={`${appName} mascot`} width={96} height={96} className="mx-auto mb-4" />
@@ -47,7 +48,7 @@ export default function NfcTagLandingPage() {
             </Button>
           </CardContent>
         </Card>
-      </main>
+      </section>
     </>
   );
 }

--- a/src/pages/t/[id].tsx
+++ b/src/pages/t/[id].tsx
@@ -1,0 +1,59 @@
+import Head from 'next/head';
+import Link from 'next/link';
+import Image from 'next/image';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Nfc } from 'lucide-react';
+import { useCommonConfig } from '@/adapters/external/Provider';
+
+// Fallback landing for NFC habit tags (lazytax.club/t/{tagId}). Owners with the
+// app never see this page — the OS intercepts /t/* via Universal/App Links and
+// opens neon directly. This renders only for visitors without the app (or
+// strangers scanning someone else's tag), so it is a pure marketing pitch: it
+// resolves nothing and shows no habit data (tag ids mean nothing without the
+// owner's auth).
+export default function NfcTagLandingPage() {
+  const common = useCommonConfig();
+  const appName = common.app.name;
+
+  return (
+    <>
+      <Head>
+        <title>{`You found a ${appName} habit tag`}</title>
+        <meta
+          name="description"
+          content={`This NFC tag completes a habit in ${appName} — the app that puts real money on the line for your habits.`}
+        />
+        <meta name="robots" content="noindex" />
+      </Head>
+      <main className="flex min-h-screen items-center justify-center px-4 py-12">
+        <Card className="w-full max-w-md text-center">
+          <CardHeader className="items-center">
+            <Image src="/mascot.svg" alt={`${appName} mascot`} width={96} height={96} className="mx-auto mb-4" />
+            <div className="mx-auto mb-2 flex h-10 w-10 items-center justify-center rounded-full bg-primary/10">
+              <Nfc className="h-5 w-5 text-primary" aria-hidden />
+            </div>
+            <CardTitle>This is a {appName} habit tag</CardTitle>
+            <CardDescription>
+              Someone taps this tag every day to keep a habit — miss a day and their stake goes to charity.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              Got the app? Tap the tag again and it opens automatically. Curious how it works?
+            </p>
+            <Button asChild className="w-full">
+              <Link href="/">Discover {appName}</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </main>
+    </>
+  );
+}
+
+// Force SSR: dynamic routes need a data-fetching method under the Pages
+// Router, and this page must render for any tag id without a build-time list.
+export async function getServerSideProps() {
+  return { props: {} };
+}


### PR DESCRIPTION
## What

Web half of NFC habit tags: makes `lazytax.club/t/{tagId}` open the neon app (Universal/App Links) and gives everyone else a marketing fallback page.

ClickUp: [86ey8e6k6](https://app.clickup.com/t/86ey8e6k6) · Companion PRs: zinc AtomiCloud/alcohol.zinc#71

## Changes

- **`/.well-known/apple-app-site-association`** — `applinks` for `/t/*`, all 3 neon flavors (`MNPSXJP9PN.cloud.atomi.alcohol.neon.{pichu,pikachu,raichu}`). Served as `application/json` via `public/_headers` (Cloudflare) since the file is extensionless
- **`/.well-known/assetlinks.json`** — Android App Links for `cloud.atomi.alcohol_neon.{pichu,pikachu,raichu}`
- **`pages/t/[id].tsx`** — SSR fallback landing: shown only when the app isn't installed (OS intercepts otherwise). Marketing pitch + CTA to `/`; `noindex`; shows zero habit data (tag ids resolve to nothing without the owner's auth)

## ⚠️ Follow-ups required before Android links verify

1. `sha256_cert_fingerprints` are **placeholders** (`REPLACE_WITH_PLAY_APP_SIGNING_SHA256`) — fill from Play Console → App integrity → App signing key certificate. iOS verification is unaffected and works as-is
2. CTA links to `/` because no public store listings exist yet — swap in App Store / Play buttons at launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pHz59ehHCiZz134oWxVeK