### PR TITLE
fix: show DurianCloud LLC entity and US legal framing

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -58,8 +58,9 @@ export function Footer() {
           {/* Company Info */}
           <div className="text-center space-y-2">
             <p className="text-sm font-medium text-slate-900 dark:text-slate-100">{appName}</p>
-            <p className="text-xs text-slate-600 dark:text-slate-400">2108 N ST #15772</p>
-            <p className="text-xs text-slate-600 dark:text-slate-400">SACRAMENTO, CA 95816, USA</p>
+            <p className="text-xs text-slate-600 dark:text-slate-400">DurianCloud LLC</p>
+            <p className="text-xs text-slate-600 dark:text-slate-400">2108 N Street, #15772</p>
+            <p className="text-xs text-slate-600 dark:text-slate-400">Sacramento, CA 95816, United States</p>
           </div>
 
           {/* Social Media & Contact */}
@@ -182,7 +183,7 @@ export function Footer() {
             <p className="text-xs text-slate-600 dark:text-slate-400">
               © {year} {appName}. All rights reserved.
             </p>
-            <p className="text-xs text-slate-500 dark:text-slate-500 mt-1">Registered business in Singapore</p>
+            <p className="text-xs text-slate-500 dark:text-slate-500 mt-1">Registered business in the United States</p>
           </div>
         </div>
       </div>

--- a/src/pages/legal/2025-09-26/privacy.tsx
+++ b/src/pages/legal/2025-09-26/privacy.tsx
@@ -195,7 +195,7 @@ export default function PrivacyPolicy() {
 
           <Card className="mb-6">
             <CardHeader>
-              <CardTitle>Data Subject Rights (PDPA/GDPR)</CardTitle>
+              <CardTitle>Data Subject Rights (CCPA/GDPR)</CardTitle>
             </CardHeader>
             <CardContent className="space-y-3 text-slate-700 dark:text-slate-300">
               <p>Subject to applicable laws, you have the following rights regarding your personal data:</p>
@@ -235,7 +235,8 @@ export default function PrivacyPolicy() {
             </CardHeader>
             <CardContent className="space-y-3 text-slate-700 dark:text-slate-300">
               <p>
-                We generally process data within Singapore. If we transfer personal data outside Singapore, we will:
+                We generally process data within the United States. If we transfer personal data outside the United
+                States, we will:
               </p>
               <ul className="list-disc pl-6 space-y-2">
                 <li>Obtain your consent where required</li>
@@ -272,12 +273,12 @@ export default function PrivacyPolicy() {
             </CardHeader>
             <CardContent className="space-y-3 text-slate-700 dark:text-slate-300">
               <p>
-                This policy complies with applicable data protection laws including the Personal Data Protection Act
-                (PDPA) of Singapore and the General Data Protection Regulation (GDPR) where applicable.
+                This policy complies with applicable data protection laws including the California Consumer Privacy Act
+                (CCPA/CPRA) and the General Data Protection Regulation (GDPR) where applicable.
               </p>
               <p>
-                For Singapore residents: This policy is aligned with PDPA requirements for consent, notification,
-                access, and correction obligations.
+                For California residents: This policy is aligned with CCPA/CPRA requirements for notice, access,
+                deletion, and correction obligations.
               </p>
               <p>
                 For EU residents: Where GDPR applies, we process personal data lawfully, fairly, and transparently in
@@ -298,7 +299,7 @@ export default function PrivacyPolicy() {
                 <strong>Email:</strong> chingwee@lazytax.club
               </p>
               <p>
-                <strong>Address:</strong> 2108 N ST #15772, SACRAMENTO, CA 95816, USA
+                <strong>Address:</strong> DurianCloud LLC, 2108 N Street, #15772, Sacramento, CA 95816, United States
               </p>
               <p>
                 For general privacy questions or to exercise your data subject rights, contact our Privacy Officer. For

--- a/src/pages/legal/2025-09-26/privacy.tsx
+++ b/src/pages/legal/2025-09-26/privacy.tsx
@@ -165,6 +165,10 @@ export default function PrivacyPolicy() {
                 <li>Access, correct, or delete certain personal information, subject to legal exceptions.</li>
                 <li>Opt out of marketing at any time without affecting transactional messages.</li>
                 <li>Control cookie and tracking preferences via your browser or device settings.</li>
+                <li>
+                  California residents have additional rights described in the &quot;Data Subject Rights
+                  (CCPA/GDPR)&quot; section below.
+                </li>
               </ul>
             </CardContent>
           </Card>
@@ -221,10 +225,26 @@ export default function PrivacyPolicy() {
                 <li>
                   <strong>Restrict:</strong> Request limitation of processing in certain circumstances
                 </li>
+                <li>
+                  <strong>Opt Out of Sale/Sharing (California):</strong> We do not sell personal information or share it
+                  for cross-context behavioral advertising. If that ever changes, we will provide a &quot;Do Not Sell or
+                  Share My Personal Information&quot; opt-out as required by the CCPA/CPRA
+                </li>
+                <li>
+                  <strong>Limit Sensitive Personal Information (California):</strong> We use sensitive personal
+                  information only for purposes permitted by the CCPA/CPRA, such as providing the Service and preventing
+                  fraud
+                </li>
+                <li>
+                  <strong>Non-Discrimination:</strong> We will not discriminate against you (e.g., deny service, charge
+                  different prices, or degrade quality) for exercising any of these rights
+                </li>
               </ul>
               <p>
-                To exercise these rights, submit a request in writing to our Privacy Officer. We will respond within 30
-                days (or as required by applicable law) and may require identity verification.
+                To exercise these rights, submit a request in writing to our Privacy Officer (contact details in the
+                &quot;Privacy Officer &amp; Contact&quot; section below). California residents may also have an
+                authorized agent submit a request on their behalf. We will respond within 30 days (or as required by
+                applicable law, e.g., 45 days under the CCPA/CPRA) and may require identity verification.
               </p>
             </CardContent>
           </Card>
@@ -278,7 +298,10 @@ export default function PrivacyPolicy() {
               </p>
               <p>
                 For California residents: This policy is aligned with CCPA/CPRA requirements for notice, access,
-                deletion, and correction obligations.
+                deletion, correction, opt-out of sale/sharing, limits on sensitive personal information, and
+                non-discrimination. We do not sell personal information or share it for cross-context behavioral
+                advertising. To exercise any of these rights, contact our Privacy Officer as described in the &quot;Data
+                Subject Rights&quot; section above.
               </p>
               <p>
                 For EU residents: Where GDPR applies, we process personal data lawfully, fairly, and transparently in

--- a/src/pages/legal/README.md
+++ b/src/pages/legal/README.md
@@ -18,7 +18,7 @@ legal/
 
 ### 2025-09-26
 - **Initial LazyTax-specific version**
-- Added PDPA/GDPR compliance sections
+- Added CCPA/GDPR compliance sections
 - Added Privacy Officer details (Ho Ching Wee, chingwee@lazytax.club)
 - Added custom frequency habits support (daily, weekly, custom intervals)
 - Added streak and gamification data handling

--- a/src/pages/legal/index.tsx
+++ b/src/pages/legal/index.tsx
@@ -7,9 +7,9 @@ import { useConfig } from '@/adapters/external/Provider';
 const legalVersions = [
   {
     date: '2025-09-26',
-    description: 'Initial LazyTax-specific version with PDPA/GDPR compliance and charity donation framework',
+    description: 'Initial LazyTax-specific version with CCPA/GDPR compliance and charity donation framework',
     changes: [
-      'Added PDPA/GDPR compliance sections',
+      'Added CCPA/GDPR compliance sections',
       'Added Privacy Officer details (Ho Ching Wee, chingwee@lazytax.club)',
       'Added custom frequency habits support (daily, weekly, custom intervals)',
       'Added streak and gamification data handling',


### PR DESCRIPTION
## Summary

- Footer: add **DurianCloud LLC** above the Sacramento address and change the tagline to "Registered business in the United States"
- Privacy policy: contact address now includes the entity name; reframe Singapore/PDPA sections to California **CCPA/CPRA** (data processed within the United States); GDPR references kept
- Legal version history (`legal/index.tsx`, `legal/README.md`): PDPA → CCPA in descriptions

Follows up on `af45f72` which moved the mailing address to Sacramento but kept the Singapore legal framing.

> Note: the CCPA/CPRA reframing was a mechanical swap — worth a legal pass for CCPA-specific disclosures (e.g. Do Not Sell/Share) before production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Legal & Compliance**
  * Updated the privacy policy from Singapore PDPA references to CCPA/CPRA and GDPR terminology.
  * Expanded “Data Subject Rights” with California-specific opt-out, sensitive data limits, and non-discrimination.
  * Refreshed international data transfer and regulatory compliance language, including CCPA/CPRA timing guidance.
  * Updated Privacy Officer and business address details.
  * Revised footer legal text to reflect U.S. registration and updated footer details.
  * Updated the legal versions history to align with the latest CCPA/GDPR coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->