### PR TITLE
Billing: tell the truth about prorated upgrades

### DIFF
--- a/src/lib/billing/pricing.ts
+++ b/src/lib/billing/pricing.ts
@@ -16,9 +16,31 @@ export const TIER_PRICING: Record<PaidTier, TierPricing> = {
   ultimate: { label: 'Ultimate', launchCents: 799, originalCents: 1499 },
 };
 
-// Rank ordering decides upgrade (immediate charge, period resets) vs
-// downgrade (applies at period end) messaging.
+// Rank ordering decides upgrade (immediate, prorated difference, renewal
+// date kept) vs downgrade (applies at period end) messaging.
 export const TIER_RANK: Record<Tier, number> = { free: 0, pro: 1, ultimate: 2 };
+
+/**
+ * Mirrors zinc's upgrade proration (ManagementService.Subscribe): charge only
+ * the price difference for the remaining fraction of the current period,
+ * floored to the cent. zinc computes the authoritative amount at confirm time
+ * with a later "now", so the real charge is never higher than this estimate.
+ * Returns null when the period bounds are missing or invalid.
+ */
+export function estimateProratedUpgradeCents(
+  fromCents: number,
+  toCents: number,
+  periodStart: string | null | undefined,
+  periodEnd: string | null | undefined,
+): number | null {
+  if (!periodStart || !periodEnd) return null;
+  const start = new Date(periodStart).getTime();
+  const end = new Date(periodEnd).getTime();
+  if (Number.isNaN(start) || Number.isNaN(end) || end <= start) return null;
+  const remaining = Math.max(0, end - Date.now());
+  const fraction = remaining / (end - start);
+  return Math.floor((toCents - fromCents) * fraction);
+}
 
 export function parsePaidTier(value: unknown): PaidTier | null {
   return value === 'pro' || value === 'ultimate' ? value : null;

--- a/src/lib/billing/pricing.ts
+++ b/src/lib/billing/pricing.ts
@@ -23,8 +23,11 @@ export const TIER_RANK: Record<Tier, number> = { free: 0, pro: 1, ultimate: 2 };
 /**
  * Mirrors zinc's upgrade proration (ManagementService.Subscribe): charge only
  * the price difference for the remaining fraction of the current period,
- * floored to the cent. zinc computes the authoritative amount at confirm time
- * with a later "now", so the real charge is never higher than this estimate.
+ * floored to the cent. `nowMs` must come from the SERVER clock (SSR time): the
+ * confirm happens strictly later in server time, so the real charge is never
+ * higher than this estimate — a client clock could not guarantee that.
+ * Remaining time is clamped to the period so a not-yet-started period can
+ * never estimate above the full price difference.
  * Returns null when the period bounds are missing or invalid.
  */
 export function estimateProratedUpgradeCents(
@@ -32,12 +35,13 @@ export function estimateProratedUpgradeCents(
   toCents: number,
   periodStart: string | null | undefined,
   periodEnd: string | null | undefined,
+  nowMs: number,
 ): number | null {
   if (!periodStart || !periodEnd) return null;
   const start = new Date(periodStart).getTime();
   const end = new Date(periodEnd).getTime();
   if (Number.isNaN(start) || Number.isNaN(end) || end <= start) return null;
-  const remaining = Math.max(0, end - Date.now());
+  const remaining = Math.min(Math.max(0, end - nowMs), end - start);
   const fraction = remaining / (end - start);
   return Math.floor((toCents - fromCents) * fraction);
 }

--- a/src/lib/billing/use-subscription.ts
+++ b/src/lib/billing/use-subscription.ts
@@ -12,7 +12,7 @@ export interface UseSubscriptionActions {
   subscribe: (tier: PaidTier) => Promise<Result<SubscriptionRes, Problem>>;
   /** Stop renewal at period end; access is retained until then. */
   cancel: () => Promise<Result<SubscriptionRes, Problem>>;
-  /** Upgrade (immediate charge, period resets) or downgrade (applies at period end). */
+  /** Upgrade (immediate, charges the prorated difference, renewal date kept) or downgrade (applies at period end). */
   changeTier: (tier: Tier) => Promise<Result<SubscriptionRes, Problem>>;
   /**
    * Undo a pending cancel-at-period-end: zinc has no dedicated un-cancel

--- a/src/pages/billing/index.tsx
+++ b/src/pages/billing/index.tsx
@@ -33,7 +33,12 @@ import type { Problem } from '@/lib/problem/core';
 import { usePaymentConsent } from '@/lib/payment/use-payment-consent';
 import { AlertCircle, ArrowDownCircle, ArrowUpCircle, CreditCard, RotateCcw, XCircle } from 'lucide-react';
 
-type BillingPageProps = { initial: ResultSerial<SubscriptionRes, Problem> };
+type BillingPageProps = {
+  initial: ResultSerial<SubscriptionRes, Problem>;
+  // Server-clock render time: keeps the prorated-upgrade estimate an upper
+  // bound on what zinc will charge, regardless of the visitor's clock.
+  serverNow: number;
+};
 
 type PendingAction = 'cancel' | 'resume' | 'upgrade' | 'downgrade' | null;
 
@@ -44,7 +49,7 @@ function formatDate(iso: string | null | undefined): string {
   return d.toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' });
 }
 
-export default function BillingPage({ initial }: BillingPageProps) {
+export default function BillingPage({ initial, serverNow }: BillingPageProps) {
   const router = useRouter();
   const problemReporter = useProblemReporter();
   const { cancel, changeTier, unCancel } = useSubscription();
@@ -72,6 +77,7 @@ export default function BillingPage({ initial }: BillingPageProps) {
           TIER_PRICING[otherTier].launchCents,
           sub.periodStart,
           sub.periodEnd,
+          serverNow,
         )
       : null;
 
@@ -344,7 +350,7 @@ export default function BillingPage({ initial }: BillingPageProps) {
                   otherIsUpgrade ? (
                     <span>
                       {upgradeEstimateCents != null && upgradeEstimateCents <= 0 ? (
-                        <>Nothing to pay now — you're right at your renewal date.</>
+                        <>Nothing to pay now — the difference for the time left rounds to $0.</>
                       ) : upgradeEstimateCents != null ? (
                         <>
                           You'll pay about {formatUsdCents(upgradeEstimateCents)} now — just the price difference for
@@ -392,6 +398,6 @@ export const getServerSideProps = withServerSideAtomi(
 
     const result = await apiTree.alcohol.zinc.api.vSubscriptionDetail({ version: '1.0', userId });
     const initial: ResultSerial<SubscriptionRes, Problem> = await result.serial();
-    return { props: { initial } };
+    return { props: { initial, serverNow: Date.now() } };
   },
 );

--- a/src/pages/billing/index.tsx
+++ b/src/pages/billing/index.tsx
@@ -18,6 +18,7 @@ import { chargeFailureIntentStatus, classifyBillingError } from '@/lib/billing/e
 import {
   TIER_PRICING,
   TIER_RANK,
+  estimateProratedUpgradeCents,
   formatUsdCents,
   parsePaidTier,
   tierLabel,
@@ -64,6 +65,15 @@ export default function BillingPage({ initial }: BillingPageProps) {
   const isPaid = paidTier != null && (sub.status === 'active' || sub.status === 'grace');
   const otherTier: PaidTier | null = paidTier === 'pro' ? 'ultimate' : paidTier === 'ultimate' ? 'pro' : null;
   const otherIsUpgrade = paidTier != null && otherTier != null && TIER_RANK[otherTier] > TIER_RANK[paidTier];
+  const upgradeEstimateCents =
+    otherIsUpgrade && paidTier != null && otherTier != null
+      ? estimateProratedUpgradeCents(
+          TIER_PRICING[paidTier].launchCents,
+          TIER_PRICING[otherTier].launchCents,
+          sub.periodStart,
+          sub.periodEnd,
+        )
+      : null;
 
   const runAction = async (action: () => Promise<Result<SubscriptionRes, Problem>>, source: string) => {
     setActing(true);
@@ -333,8 +343,18 @@ export default function BillingPage({ initial }: BillingPageProps) {
                 description={
                   otherIsUpgrade ? (
                     <span>
-                      You'll be charged {formatUsdCents(TIER_PRICING[otherTier].launchCents)} now and your billing
-                      period restarts today.
+                      {upgradeEstimateCents != null && upgradeEstimateCents <= 0 ? (
+                        <>Nothing to pay now — you're right at your renewal date.</>
+                      ) : upgradeEstimateCents != null ? (
+                        <>
+                          You'll pay about {formatUsdCents(upgradeEstimateCents)} now — just the price difference for
+                          the rest of this period.
+                        </>
+                      ) : (
+                        <>You'll pay only the price difference for the rest of this period now.</>
+                      )}{' '}
+                      Your renewal date stays {formatDate(sub.periodEnd)}, then it's{' '}
+                      {formatUsdCents(TIER_PRICING[otherTier].launchCents)}/month.
                     </span>
                   ) : (
                     <span>


### PR DESCRIPTION
## What

The upgrade confirm dialog said **"You'll be charged $7.99 now and your billing period restarts today"** — both halves wrong. zinc actually charges `(new − old) × remaining fraction of the period`, floored to the cent, and keeps the renewal anniversary (`ManagementService.cs`), even flipping the tier free of charge when the prorate rounds to $0 near the anniversary.

Now the dialog:
- shows the computed prorated estimate ("You'll pay about $2.10 now — just the price difference for the rest of this period") using zinc's own formula over `periodStart`/`periodEnd`; the server computes with a later "now", so the real charge is never higher than the estimate
- handles the $0 case ("Nothing to pay now — you're right at your renewal date")
- states the renewal date does not move

Also fixes the stale "period resets" comments in `pricing.ts` / `use-subscription.ts` that baked the wrong model into the frontend.

Part of the subscription-lifecycle plan (ClickUp 86eyg1518); backend behavior documented in `alcohol.zinc/docs/subscription-lifecycle.md`.

## Tests

`tsc --noEmit` + biome clean (pre-commit hooks passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FdBrWdewXDddGS6N5jaXcD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upgrades now show an estimated prorated charge based on the remaining billing period.
  * Upgrade confirmations clarify that the charge occurs immediately while the renewal date remains unchanged.
  * Near renewal, zero or negative upgrade amounts are handled appropriately.

* **Bug Fixes**
  * Prevented upgrades from charging the full new plan price or restarting the billing period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->